### PR TITLE
Asset Drained Bot Update #2

### DIFF
--- a/asset-drained/README.md
+++ b/asset-drained/README.md
@@ -23,7 +23,7 @@ This bot detects if an asset is fully drained from a contract within a block. It
   - Metadata:
     - contract - the contract's address
     - asset - the asset's address
-    - txFroms - the EOA(s) that initiated the transaction(s)
+    - initiators - the EOA(s) that initiated the transaction(s)
     - txHashes - the hash(es) of the transaction(s) in which the contract was drained
     - blockNumber - the block number at the time of the contract drain
   - Addresses contain the list of addresses that received the assets from the drained contract

--- a/asset-drained/README.md
+++ b/asset-drained/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This bot detects if an asset is fully drained from a contract. It monitors ERC20 and native tokens transfers from contracts and raises an alert when a contract, having a non-zero token balance in the recent past (10 mins ago), now has 0.
+This bot detects if an asset is fully drained from a contract within a block. It monitors ERC20 and native tokens transfers from contracts and raises an alert when a contract, having a non-zero token balance in the recent past (10 mins ago), now has 0.
 
 ## Supported Chains
 
@@ -23,7 +23,8 @@ This bot detects if an asset is fully drained from a contract. It monitors ERC20
   - Metadata:
     - contract - the contract's address
     - asset - the asset's address
-    - txHashes - the hashes of the transactions in which the contract was drained
+    - txFroms - the EOA(s) that initiated the transaction(s)
+    - txHashes - the hash(es) of the transaction(s) in which the contract was drained
     - blockNumber - the block number at the time of the contract drain
   - Addresses contain the list of addresses that received the assets from the drained contract
 
@@ -35,5 +36,6 @@ The bot behaviour can be verified by running:
 
 - `npm run block 13499798,13499799` (CREAM exploit).
 - `npm run block 15572488,15572489` (WinterMute exploit).
+- `npm run block 15794364,15794365` (OlympusDAO exploit).
 
 Every block we process the transactions from the previous one so when testing you should provide the exploit block and the next one.

--- a/asset-drained/package.json
+++ b/asset-drained/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset-drained",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Detects if an asset is fully drained from a contract",
   "repository": "https://github.com/NethermindEth/forta-starter-kits/tree/main/asset-drained",
   "chainIds": [

--- a/asset-drained/src/agent.js
+++ b/asset-drained/src/agent.js
@@ -23,7 +23,7 @@ const initialize = async () => {
 };
 
 const handleTransaction = async (txEvent) => {
-  const { hash, from: txFrom } = txEvent;
+  const { hash, from: txFrom, blockNumber } = txEvent;
   txEvent
     .filterLog(ERC20_TRANSFER_EVENT)
     .filter((event) => !event.args.value.eq(ZERO))
@@ -39,6 +39,7 @@ const handleTransaction = async (txEvent) => {
           asset,
           address: from,
           value: ZERO,
+          blockNumber,
           txs: {},
         };
       }
@@ -47,6 +48,7 @@ const handleTransaction = async (txEvent) => {
           asset,
           address: to,
           value: ZERO,
+          blockNumber,
           txs: {},
         };
       }
@@ -74,6 +76,7 @@ const handleTransaction = async (txEvent) => {
           asset: "native",
           address: from,
           value: ZERO,
+          blockNumber,
           txs: {},
         };
       }
@@ -83,6 +86,7 @@ const handleTransaction = async (txEvent) => {
           asset: "native",
           address: to,
           value: ZERO,
+          blockNumber,
           txs: {},
         };
       }
@@ -200,7 +204,7 @@ const handleBlock = async (blockEvent) => {
                 .map((tx) => tx.hash)
             ),
           ],
-          blockNumber: blockNumber - 1,
+          blockNumber: t.blockNumber,
         },
         addresses: [...new Set(Object.keys(t.txs))],
       })

--- a/asset-drained/src/agent.js
+++ b/asset-drained/src/agent.js
@@ -23,7 +23,7 @@ const initialize = async () => {
 };
 
 const handleTransaction = async (txEvent) => {
-  const { hash } = txEvent;
+  const { hash, from: txFrom } = txEvent;
   txEvent
     .filterLog(ERC20_TRANSFER_EVENT)
     .filter((event) => !event.args.value.eq(ZERO))
@@ -54,9 +54,9 @@ const handleTransaction = async (txEvent) => {
       transfersObj[hashFrom].value = transfersObj[hashFrom].value.sub(value);
 
       if (!transfersObj[hashFrom].txs[to]) {
-        transfersObj[hashFrom].txs[to] = [hash];
+        transfersObj[hashFrom].txs[to] = [{ hash, txFrom }];
       } else {
-        transfersObj[hashFrom].txs[to].push(hash);
+        transfersObj[hashFrom].txs[to].push({ hash, txFrom });
       }
 
       transfersObj[hashTo].value = transfersObj[hashTo].value.add(value);
@@ -90,9 +90,9 @@ const handleTransaction = async (txEvent) => {
       transfersObj[hashFrom].value = transfersObj[hashFrom].value.sub(value);
 
       if (!transfersObj[hashFrom].txs[to]) {
-        transfersObj[hashFrom].txs[to] = [hash];
+        transfersObj[hashFrom].txs[to] = [{ hash, txFrom }];
       } else {
-        transfersObj[hashFrom].txs[to].push(hash);
+        transfersObj[hashFrom].txs[to].push({ hash, txFrom });
       }
 
       transfersObj[hashTo].value = transfersObj[hashTo].value.add(value);
@@ -186,7 +186,20 @@ const handleBlock = async (blockEvent) => {
         metadata: {
           contract: t.address,
           asset: t.asset,
-          txHashes: [...new Set(Object.values(t.txs).flat())],
+          txFroms: [
+            ...new Set(
+              Object.values(t.txs)
+                .flat()
+                .map((tx) => tx.txFrom)
+            ),
+          ],
+          txHashes: [
+            ...new Set(
+              Object.values(t.txs)
+                .flat()
+                .map((tx) => tx.hash)
+            ),
+          ],
           blockNumber: blockNumber - 1,
         },
         addresses: [...new Set(Object.keys(t.txs))],

--- a/asset-drained/src/agent.js
+++ b/asset-drained/src/agent.js
@@ -190,7 +190,7 @@ const handleBlock = async (blockEvent) => {
         metadata: {
           contract: t.address,
           asset: t.asset,
-          txFroms: [
+          initiators: [
             ...new Set(
               Object.values(t.txs)
                 .flat()

--- a/asset-drained/src/agent.spec.js
+++ b/asset-drained/src/agent.spec.js
@@ -51,6 +51,7 @@ describe("Asset drained bot test suite", () => {
   describe("handleTransaction", () => {
     const mockTxEvent = {
       filterLog: jest.fn(),
+      blockNumber: 9999,
       hash: ethers.utils.formatBytes32String("0x352352"),
       from: address4,
       traces: [],
@@ -92,6 +93,7 @@ describe("Asset drained bot test suite", () => {
         asset,
         address: address1,
         value: ethers.BigNumber.from(-10),
+        blockNumber: 9999,
         txs: {
           "0x0000000000000000000000000000000000000003": [
             { hash: ethers.utils.formatBytes32String("0x352352"), txFrom: address4 },
@@ -102,6 +104,7 @@ describe("Asset drained bot test suite", () => {
         asset,
         address: address2,
         value: ethers.BigNumber.from(0),
+        blockNumber: 9999,
         txs: {
           "0x0000000000000000000000000000000000000004": [
             { hash: ethers.utils.formatBytes32String("0x352352"), txFrom: address4 },
@@ -112,6 +115,7 @@ describe("Asset drained bot test suite", () => {
         asset,
         address: address3,
         value: ethers.BigNumber.from(10),
+        blockNumber: 9999,
         txs: {},
       });
     });
@@ -120,12 +124,14 @@ describe("Asset drained bot test suite", () => {
   describe("handleBlock", () => {
     const mockTxEvent = {
       filterLog: jest.fn(),
+      blockNumber: 9999,
       hash: ethers.utils.formatBytes32String("0x2352352"),
       from: address4,
       traces: [],
     };
     const mockTxEvent2 = {
       filterLog: jest.fn(),
+      blockNumber: 9999,
       hash: ethers.utils.formatBytes32String("0x442352352"),
       from: address5,
       traces: [],

--- a/asset-drained/src/agent.spec.js
+++ b/asset-drained/src/agent.spec.js
@@ -10,6 +10,8 @@ const asset = createAddress("0x01");
 const address1 = createAddress("0x02");
 const address2 = createAddress("0x03");
 const address3 = createAddress("0x04");
+const address4 = createAddress("0x05");
+const address5 = createAddress("0x06");
 
 const hashCode1 = hashCode(address1, asset);
 const hashCode2 = hashCode(address2, asset);
@@ -50,6 +52,7 @@ describe("Asset drained bot test suite", () => {
     const mockTxEvent = {
       filterLog: jest.fn(),
       hash: ethers.utils.formatBytes32String("0x352352"),
+      from: address4,
       traces: [],
     };
 
@@ -90,7 +93,9 @@ describe("Asset drained bot test suite", () => {
         address: address1,
         value: ethers.BigNumber.from(-10),
         txs: {
-          "0x0000000000000000000000000000000000000003": [ethers.utils.formatBytes32String("0x352352")],
+          "0x0000000000000000000000000000000000000003": [
+            { hash: ethers.utils.formatBytes32String("0x352352"), txFrom: address4 },
+          ],
         },
       });
       expect(getTransfersObj()[hashCode2]).toStrictEqual({
@@ -98,7 +103,9 @@ describe("Asset drained bot test suite", () => {
         address: address2,
         value: ethers.BigNumber.from(0),
         txs: {
-          "0x0000000000000000000000000000000000000004": [ethers.utils.formatBytes32String("0x352352")],
+          "0x0000000000000000000000000000000000000004": [
+            { hash: ethers.utils.formatBytes32String("0x352352"), txFrom: address4 },
+          ],
         },
       });
       expect(getTransfersObj()[hashCode3]).toStrictEqual({
@@ -114,11 +121,13 @@ describe("Asset drained bot test suite", () => {
     const mockTxEvent = {
       filterLog: jest.fn(),
       hash: ethers.utils.formatBytes32String("0x2352352"),
+      from: address4,
       traces: [],
     };
     const mockTxEvent2 = {
       filterLog: jest.fn(),
       hash: ethers.utils.formatBytes32String("0x442352352"),
+      from: address5,
       traces: [],
     };
     const mockBlockEvent = { blockNumber: 10_000 };
@@ -162,6 +171,7 @@ describe("Asset drained bot test suite", () => {
           metadata: {
             contract: address1,
             asset,
+            txFroms: [address4],
             txHashes: [ethers.utils.formatBytes32String("0x2352352")],
             blockNumber: 9999,
           },
@@ -207,6 +217,7 @@ describe("Asset drained bot test suite", () => {
           metadata: {
             contract: address1,
             asset,
+            txFroms: [address4, address5],
             txHashes: [ethers.utils.formatBytes32String("0x2352352"), ethers.utils.formatBytes32String("0x442352352")],
             blockNumber: 9999,
           },

--- a/asset-drained/src/agent.spec.js
+++ b/asset-drained/src/agent.spec.js
@@ -177,7 +177,7 @@ describe("Asset drained bot test suite", () => {
           metadata: {
             contract: address1,
             asset,
-            txFroms: [address4],
+            initiators: [address4],
             txHashes: [ethers.utils.formatBytes32String("0x2352352")],
             blockNumber: 9999,
           },
@@ -223,7 +223,7 @@ describe("Asset drained bot test suite", () => {
           metadata: {
             contract: address1,
             asset,
-            txFroms: [address4, address5],
+            initiators: [address4, address5],
             txHashes: [ethers.utils.formatBytes32String("0x2352352"), ethers.utils.formatBytes32String("0x442352352")],
             blockNumber: 9999,
           },


### PR DESCRIPTION
## Asset Drained Bot
- [x] Update a bot logic/test/documentation

## Changes
- Added `txFrom` to metadata
- Avoided hardcoding the `blockNumber` to the metadata, as I randomly noticed [this](https://explorer.forta.network/alert/0x2c298e783b5e172c18abab448db002fd282a6d57f0f9131a705cee6c47bf56db) alert, in the metadata of which, the block number is actually wrong.
