### PR TITLE
Flashloan Detector 02.02 - Update

### DIFF
--- a/flashloan-detector/README.md
+++ b/flashloan-detector/README.md
@@ -24,17 +24,20 @@ Describe each of the type of alerts fired by this agent
   - Severity is always set to "low"
   - Type is always set to "exploit"
   - Metadata:
-    - tokens - array of all tokens involved in the transaction
+    - `profit` - profit made from the flashloan
+    - `tokens` - array of all tokens involved in the transaction
 
 - FLASHLOAN-ATTACK-WITH-HIGH-PROFIT
   - Fired when a transaction contains a flashoan and the borrower made significant profit
   - Severity is always set to "high"
   - Type is always set to "exploit"
   - Metadata:
-    - tokens - array of all tokens involved in the transaction
+    - `profit` - profit made from the flashloan
+    - `tokens` - array of all tokens involved in the transaction
 
 ## Test Data
 
 The bot behaviour can be verified with the following transactions:
 
 - [0xe7e0474793aad11875c131ebd7582c8b73499dd3c5a473b59e6762d4e373d7b8](https://etherscan.io/tx/0xe7e0474793aad11875c131ebd7582c8b73499dd3c5a473b59e6762d4e373d7b8) (SaddleFinance exploit)
+- [0x47c7ab4a9e829415322c8933cf17261cd666dbeb875f0d559ca2785d21cae661](https://etherscan.io/tx/0x47c7ab4a9e829415322c8933cf17261cd666dbeb875f0d559ca2785d21cae661) (Curve Finance exploit)

--- a/flashloan-detector/package-lock.json
+++ b/flashloan-detector/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "flashloan-detection-bot",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "flashloan-detection-bot",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "dependencies": {
         "axios": "^0.27.2",
         "ethers-multicall": "^0.2.3",
-        "forta-agent": "^0.1.6"
+        "forta-agent": "^0.1.15"
       },
       "devDependencies": {
         "jest": "^28.1.1",
@@ -1943,6 +1943,11 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.10",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
@@ -2040,6 +2045,14 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/asynckit": {
@@ -2980,12 +2993,14 @@
       }
     },
     "node_modules/forta-agent": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/forta-agent/-/forta-agent-0.1.6.tgz",
-      "integrity": "sha512-8Pt7EPts7XtTfV9aJJKCzuQEvh4TKldEjpq+0l6568SR0ia8Y04ZVhy0X0iX6w1GxnpPnoe3K42xJe8OP9Q9Ng==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/forta-agent/-/forta-agent-0.1.15.tgz",
+      "integrity": "sha512-YS/KUMzQiFnTJsg9usfw0grm+wS7WURXEScIXdQZl/Cevl40mTcaRZYtrTOjjiSC7LiFHc6/4vngUgmX5i6mYA==",
       "dependencies": {
         "@grpc/grpc-js": "^1.3.6",
         "@grpc/proto-loader": "^0.6.4",
+        "@types/uuid": "^8.3.4",
+        "async-retry": "^1.3.3",
         "awilix": "^4.3.4",
         "axios": "^0.21.1",
         "ethers": "^5.5.1",
@@ -2999,6 +3014,7 @@
         "python-shell": "^3.0.0",
         "sha3": "^2.1.4",
         "shelljs": "^0.8.4",
+        "uuid": "^8.3.2",
         "yargs": "^17.0.1"
       },
       "bin": {
@@ -3011,6 +3027,14 @@
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dependencies": {
         "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/forta-agent/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/fs.realpath": {
@@ -4873,6 +4897,14 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rimraf": {
@@ -6822,6 +6854,11 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+    },
     "@types/yargs": {
       "version": "17.0.10",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
@@ -6897,6 +6934,14 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "requires": {
+        "retry": "0.13.1"
       }
     },
     "asynckit": {
@@ -7617,12 +7662,14 @@
       }
     },
     "forta-agent": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/forta-agent/-/forta-agent-0.1.6.tgz",
-      "integrity": "sha512-8Pt7EPts7XtTfV9aJJKCzuQEvh4TKldEjpq+0l6568SR0ia8Y04ZVhy0X0iX6w1GxnpPnoe3K42xJe8OP9Q9Ng==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/forta-agent/-/forta-agent-0.1.15.tgz",
+      "integrity": "sha512-YS/KUMzQiFnTJsg9usfw0grm+wS7WURXEScIXdQZl/Cevl40mTcaRZYtrTOjjiSC7LiFHc6/4vngUgmX5i6mYA==",
       "requires": {
         "@grpc/grpc-js": "^1.3.6",
         "@grpc/proto-loader": "^0.6.4",
+        "@types/uuid": "^8.3.4",
+        "async-retry": "^1.3.3",
         "awilix": "^4.3.4",
         "axios": "^0.21.1",
         "ethers": "^5.5.1",
@@ -7636,6 +7683,7 @@
         "python-shell": "^3.0.0",
         "sha3": "^2.1.4",
         "shelljs": "^0.8.4",
+        "uuid": "^8.3.2",
         "yargs": "^17.0.1"
       },
       "dependencies": {
@@ -7646,6 +7694,11 @@
           "requires": {
             "follow-redirects": "^1.14.0"
           }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -9054,6 +9107,11 @@
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
       "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
       "dev": true
+    },
+    "retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "rimraf": {
       "version": "3.0.2",

--- a/flashloan-detector/package.json
+++ b/flashloan-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashloan-detection-bot",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Forta bot that detects if a transaction contains a flashloan and the borrower made significant profit",
   "repository": "https://github.com/NethermindEth/forta-starter-kits/tree/main/flashloan-detector",
   "chainIds": [

--- a/flashloan-detector/package.json
+++ b/flashloan-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashloan-detection-bot",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Forta bot that detects if a transaction contains a flashloan and the borrower made significant profit",
   "repository": "https://github.com/NethermindEth/forta-starter-kits/tree/main/flashloan-detector",
   "chainIds": [
@@ -31,7 +31,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "ethers-multicall": "^0.2.3",
-    "forta-agent": "^0.1.6"
+    "forta-agent": "^0.1.15"
   },
   "devDependencies": {
     "prettier": "^2.7.1",

--- a/flashloan-detector/src/agent.js
+++ b/flashloan-detector/src/agent.js
@@ -78,10 +78,10 @@ function provideHandleTransaction(helper, getFlashloans, provider) {
               totalNativeProfit = totalNativeProfit.add(nativeProfit);
               break traceLoop;
             } else if (
-              (from.toLowerCase() === account || from.toLowerCase() === calledContract)
+              (from.toLowerCase() === account || from.toLowerCase() === calledContract) &&
               // Only start looping through Transfers of unknown destination (dst)
               // during the last flashloan to prevent "double counting"
-               && flashloanIndex === numOfFlashloans - 1
+              flashloanIndex === numOfFlashloans - 1
             ) {
               const nativeProfit = helper.calculateNativeProfit(traces, to.toLowerCase());
               if (nativeProfit === helper.zero) {

--- a/flashloan-detector/src/agent.js
+++ b/flashloan-detector/src/agent.js
@@ -57,7 +57,7 @@ function provideHandleTransaction(helper, getFlashloans) {
           const { name } = transferEvents[i];
           const { src, dst } = transferEvents[i].args;
 
-          if (name === "Transfer" && src.toLowerCase() === calledContract && src.toLowerCase() === initiator) {
+          if (name === "Transfer" && src.toLowerCase() === calledContract && dst.toLowerCase() === initiator) {
             const tokenProfits = helper.calculateTokenProfits(transferEvents, initiator);
             const positiveProfits = Object.values(tokenProfits).filter((i) => i > helper.zero);
             if (positiveProfits.length === 0) {
@@ -69,7 +69,7 @@ function provideHandleTransaction(helper, getFlashloans) {
               totalTokenProfits[address] = totalTokenProfits[address].add(profit);
             });
             break;
-          } else if (name === "Transfer" && src.toLowerCase() === account && src.toLowerCase() === initiator) {
+          } else if (name === "Transfer" && src.toLowerCase() === account && dst.toLowerCase() === initiator) {
             const tokenProfits = helper.calculateTokenProfits(transferEvents, initiator);
             const positiveProfits = Object.values(tokenProfits).filter((i) => i > helper.zero);
             if (positiveProfits.length === 0) {

--- a/flashloan-detector/src/agent.js
+++ b/flashloan-detector/src/agent.js
@@ -156,9 +156,9 @@ function provideHandleTransaction(helper, getFlashloans, provider) {
               }
             }
           }
-        // Check the profit of the initiator if not on mainnet
-        // or if no traces only during the last flashloan
-        } else if(flashloanIndex === numOfFlashloans - 1) {
+          // Check the profit of the initiator if not on mainnet
+          // or if no traces only during the last flashloan
+        } else if (flashloanIndex === numOfFlashloans - 1) {
           const tokenProfits = helper.calculateTokenProfits(transferEvents, initiator);
           Object.entries(tokenProfits).forEach(([address, profit]) => {
             if (!totalTokenProfits[address]) totalTokenProfits[address] = helper.zero;

--- a/flashloan-detector/src/agent.js
+++ b/flashloan-detector/src/agent.js
@@ -63,7 +63,7 @@ function provideHandleTransaction(helper, getFlashloans, provider) {
             if (!totalTokenProfits[address]) totalTokenProfits[address] = helper.zero;
             totalTokenProfits[address] = totalTokenProfits[address].add(profit);
           });
-          totalNativeProfit = nativeProfit.add(nativeProfit);
+          totalNativeProfit = totalNativeProfit.add(nativeProfit);
         }
 
         traceLoop: for (let i = traces.length - 1; i >= 0; i--) {

--- a/flashloan-detector/src/agent.js
+++ b/flashloan-detector/src/agent.js
@@ -87,7 +87,7 @@ function provideHandleTransaction(helper, getFlashloans, provider) {
               const toCode = await provider.getCode(to);
               if (toCode !== "0x") {
                 continue;
-              };
+              }
 
               const nativeProfit = helper.calculateNativeProfit(traces, to.toLowerCase());
               if (nativeProfit === helper.zero) {

--- a/flashloan-detector/src/agent.js
+++ b/flashloan-detector/src/agent.js
@@ -37,7 +37,7 @@ function provideHandleTransaction(helper, getFlashloans) {
     // Iterating from the end to find the profitable transfer instance
     for(let i = transferEvents.length -1; i >= 0; i--) {
       if(transferEvents[i].name === "Transfer" && transferEvents[i].args.src.toLowerCase() === calledContract) {
-        endRecipient = transferEvents[i]["args"]["dst"].toLowerCase();
+        endRecipient = transferEvents[i].args.dst.toLowerCase();
         break;
       }
     }

--- a/flashloan-detector/src/agent.js
+++ b/flashloan-detector/src/agent.js
@@ -169,7 +169,8 @@ function provideHandleTransaction(helper, getFlashloans, provider) {
           totalNativeProfit = totalNativeProfit.add(nativeProfit);
         }
 
-        totalBorrowed = await helper.calculateBorrowedAmount(asset, amount, chain);
+        borrowedAmount = await helper.calculateBorrowedAmount(asset, amount, chain);
+        totalBorrowed = totalBorrowed.add(borrowedAmount);
       })
     );
 

--- a/flashloan-detector/src/agent.js
+++ b/flashloan-detector/src/agent.js
@@ -83,6 +83,12 @@ function provideHandleTransaction(helper, getFlashloans, provider) {
               // during the last flashloan to prevent "double counting"
               flashloanIndex === numOfFlashloans - 1
             ) {
+              // Only proceed with recipients that are EOAs
+              const toCode = await provider.getCode(to);
+              if (toCode !== "0x") {
+                continue;
+              };
+
               const nativeProfit = helper.calculateNativeProfit(traces, to.toLowerCase());
               if (nativeProfit === helper.zero) {
                 continue;

--- a/flashloan-detector/src/agent.js
+++ b/flashloan-detector/src/agent.js
@@ -1,4 +1,4 @@
-const { Finding, FindingSeverity, FindingType, ethers } = require("forta-agent");
+const { Finding, FindingSeverity, FindingType, ethers, LabelType, EntityType } = require("forta-agent");
 const { getFlashloans: getFlashloansFn } = require("./flashloan-detector");
 const helperModule = require("./helper");
 
@@ -171,6 +171,13 @@ function provideHandleTransaction(helper, getFlashloans) {
             profit: totalProfit.toFixed(2),
             tokens: tokensArray,
           },
+          labels: [{
+            entityType: EntityType.Address,
+            entity: initiator,
+            labelType: LabelType.Attacker,
+            confidence: 90,
+            customValue: "Initiator of transaction"
+          }]
         })
       );
     } else if (percentage > PERCENTAGE_THRESHOLD) {
@@ -185,6 +192,13 @@ function provideHandleTransaction(helper, getFlashloans) {
             profit: totalProfit.toFixed(2),
             tokens: tokensArray,
           },
+          labels: [{
+            entityType: EntityType.Address,
+            entity: initiator,
+            labelType: LabelType.Attacker,
+            confidence: 60,
+            customValue: "Initiator of transaction"
+          }]
         })
       );
     } else if (totalProfit > PROFIT_THRESHOLD) {
@@ -199,6 +213,13 @@ function provideHandleTransaction(helper, getFlashloans) {
             profit: totalProfit.toFixed(2),
             tokens: tokensArray,
           },
+          labels: [{
+            entityType: EntityType.Address,
+            entity: initiator,
+            labelType: LabelType.Attacker,
+            confidence: 90,
+            customValue: "Initiator of transaction"
+          }]
         })
       );
     }

--- a/flashloan-detector/src/agent.spec.js
+++ b/flashloan-detector/src/agent.spec.js
@@ -3,6 +3,7 @@ const { provideHandleTransaction, provideInitialize } = require("./agent");
 
 const asset = "0xasset";
 const initiator = "0xfrom";
+const contractCalled = "0xtxnto";
 const chain = "ethereum";
 const nativeToken = "ethereum";
 
@@ -35,139 +36,192 @@ const mockHelper = {
 };
 
 describe("flashloan detector agent", () => {
-  describe("handleTransaction", () => {
-    let initialize;
-    let handleTransaction;
+  let initialize;
+  let handleTransaction;
 
-    const mockTxEvent = {
-      from: initiator,
-      traces: [],
-      filterLog: jest.fn(),
-      transaction: { gasPrice: 0 },
+  const mockTxEvent = {
+    from: initiator,
+    to: contractCalled,
+    traces: [],
+    filterLog: jest.fn(),
+    transaction: { gasPrice: 0 },
+  };
+
+  const mockTransferEvent = {
+    name: "Transfer",
+    args: {
+      src: contractCalled,
+      dst: initiator
+    }
+  };
+
+  beforeAll(async () => {
+    initialize = provideInitialize(mockHelper);
+    await initialize();
+    handleTransaction = provideHandleTransaction(mockHelper, mockGetFlashloans);
+  });
+
+  it("returns empty findings if there are no flashloans", async () => {
+    mockGetFlashloans.mockResolvedValueOnce([]);
+    const findings = await handleTransaction(mockTxEvent);
+
+    expect(findings).toStrictEqual([]);
+  });
+
+  it("returns a finding if there is a flashloan with high profit", async () => {
+    mockGetFlashloans.mockResolvedValueOnce([flashloan]);
+    mockTxEvent.filterLog.mockReturnValueOnce([mockTransferEvent]);
+    mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(10000);
+    mockHelper.calculateTokenProfits.mockReturnValueOnce({ [asset]: tokenProfit });
+    mockHelper.calculateNativeProfit.mockReturnValueOnce(nativeProfit);
+    mockHelper.getTransactionReceipt.mockResolvedValueOnce({ gasUsed: 0 });
+    mockHelper.calculateTokensUsdProfit.mockResolvedValueOnce(tokenUsdProfit);
+    mockHelper.calculateNativeUsdProfit.mockResolvedValueOnce(nativeUsdProfit);
+    const findings = await handleTransaction(mockTxEvent);
+
+    expect(findings).toStrictEqual([
+      Finding.fromObject({
+        name: "Flashloan detected",
+        description: `${initiator} launched flash loan attack and made profit > $100000`,
+        alertId: "FLASHLOAN-ATTACK-WITH-HIGH-PROFIT",
+        severity: FindingSeverity.High,
+        type: FindingType.Exploit,
+        metadata: {
+          profit: (tokenUsdProfit + nativeUsdProfit).toFixed(2),
+          tokens: [asset],
+        },
+      }),
+    ]);
+
+    expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
+    expect(mockHelper.calculateTokenProfits).toHaveBeenCalledWith([mockTransferEvent], initiator);
+    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([], initiator);
+    expect(mockHelper.calculateTokensUsdProfit).toHaveBeenCalledWith(
+      {
+        [asset]: tokenProfit,
+      },
+      chain
+    );
+    expect(mockHelper.calculateNativeUsdProfit).toHaveBeenCalledWith(nativeProfit, chain);
+  });
+
+  it("returns a finding if there is a flashloan with low profit", async () => {
+    mockGetFlashloans.mockResolvedValueOnce([flashloan]);
+    mockTxEvent.filterLog.mockReturnValueOnce([mockTransferEvent]);
+    mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(10000);
+    mockHelper.calculateTokenProfits.mockReturnValueOnce({ [asset]: tokenProfit });
+    mockHelper.calculateNativeProfit.mockReturnValueOnce(nativeProfit);
+    mockHelper.getTransactionReceipt.mockResolvedValueOnce({ gasUsed: 0 });
+    mockHelper.calculateTokensUsdProfit.mockResolvedValueOnce(1000);
+    mockHelper.calculateNativeUsdProfit.mockResolvedValueOnce(1000);
+    const findings = await handleTransaction(mockTxEvent);
+
+    expect(findings).toStrictEqual([
+      Finding.fromObject({
+        name: "Flashloan detected",
+        description: `${initiator} launched flash loan attack`,
+        alertId: "FLASHLOAN-ATTACK",
+        severity: FindingSeverity.Low,
+        type: FindingType.Exploit,
+        metadata: {
+          profit: (2000).toFixed(2),
+          tokens: [asset],
+        },
+      }),
+    ]);
+
+    expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
+    expect(mockHelper.calculateTokenProfits).toHaveBeenCalledWith([mockTransferEvent], initiator);
+    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([], initiator);
+    expect(mockHelper.calculateTokensUsdProfit).toHaveBeenCalledWith(
+      {
+        [asset]: tokenProfit,
+      },
+      chain
+    );
+    expect(mockHelper.calculateNativeUsdProfit).toHaveBeenCalledWith(nativeProfit, chain);
+  });
+
+  it("returns a finding if there is a flashloan with high profit and low percentage", async () => {
+    mockGetFlashloans.mockResolvedValueOnce([flashloan]);
+    mockTxEvent.filterLog.mockReturnValueOnce([mockTransferEvent]);
+    mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(100_000_000);
+    mockHelper.calculateTokenProfits.mockReturnValueOnce({ [asset]: tokenProfit });
+    mockHelper.calculateNativeProfit.mockReturnValueOnce(nativeProfit);
+    mockHelper.getTransactionReceipt.mockResolvedValueOnce({ gasUsed: 0 });
+    mockHelper.calculateTokensUsdProfit.mockResolvedValueOnce(tokenUsdProfit);
+    mockHelper.calculateNativeUsdProfit.mockResolvedValueOnce(highNativeUsdProfit);
+    const findings = await handleTransaction(mockTxEvent);
+
+    expect(findings).toStrictEqual([
+      Finding.fromObject({
+        name: "Flashloan detected",
+        description: `${initiator} launched flash loan attack and made profit > $500000`,
+        alertId: "FLASHLOAN-ATTACK-WITH-HIGH-PROFIT",
+        severity: FindingSeverity.High,
+        type: FindingType.Exploit,
+        metadata: {
+          profit: (tokenUsdProfit + highNativeUsdProfit).toFixed(2),
+          tokens: [asset],
+        },
+      }),
+    ]);
+
+    expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
+    expect(mockHelper.calculateTokenProfits).toHaveBeenCalledWith([mockTransferEvent], initiator);
+    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([], initiator);
+    expect(mockHelper.calculateTokensUsdProfit).toHaveBeenCalledWith(
+      {
+        [asset]: tokenProfit,
+      },
+      chain
+    );
+    expect(mockHelper.calculateNativeUsdProfit).toHaveBeenCalledWith(nativeProfit, chain);
+  });
+
+  it("returns a finding if there is a flashloan with low profit with a different end recipient", async () => {
+    const diffEndRecipient = "0xdst";
+    const diffMockTransferEvent = {
+      name: "Transfer",
+      args: {
+        src: contractCalled,
+        dst: diffEndRecipient
+      }
     };
 
-    beforeAll(async () => {
-      initialize = provideInitialize(mockHelper);
-      await initialize();
-      handleTransaction = provideHandleTransaction(mockHelper, mockGetFlashloans);
-    });
+    mockGetFlashloans.mockResolvedValueOnce([flashloan]);
+    mockTxEvent.filterLog.mockReturnValueOnce([diffMockTransferEvent]);
+    mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(10000);
+    mockHelper.calculateTokenProfits.mockReturnValueOnce({ [asset]: tokenProfit });
+    mockHelper.calculateNativeProfit.mockReturnValueOnce(nativeProfit);
+    mockHelper.getTransactionReceipt.mockResolvedValueOnce({ gasUsed: 0 });
+    mockHelper.calculateTokensUsdProfit.mockResolvedValueOnce(1000);
+    mockHelper.calculateNativeUsdProfit.mockResolvedValueOnce(1000);
+    const findings = await handleTransaction(mockTxEvent);
 
-    it("returns empty findings if there are no flashloans", async () => {
-      mockGetFlashloans.mockResolvedValueOnce([]);
-      const findings = await handleTransaction(mockTxEvent);
-
-      expect(findings).toStrictEqual([]);
-    });
-
-    it("returns a finding if there is a flashloan with high profit", async () => {
-      mockGetFlashloans.mockResolvedValueOnce([flashloan]);
-      mockTxEvent.filterLog.mockReturnValueOnce([]); // Mock transfers
-      mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(10000);
-      mockHelper.calculateTokenProfits.mockReturnValueOnce({ [asset]: tokenProfit });
-      mockHelper.calculateNativeProfit.mockReturnValueOnce(nativeProfit);
-      mockHelper.getTransactionReceipt.mockResolvedValueOnce({ gasUsed: 0 });
-      mockHelper.calculateTokensUsdProfit.mockResolvedValueOnce(tokenUsdProfit);
-      mockHelper.calculateNativeUsdProfit.mockResolvedValueOnce(nativeUsdProfit);
-      const findings = await handleTransaction(mockTxEvent);
-
-      expect(findings).toStrictEqual([
-        Finding.fromObject({
-          name: "Flashloan detected",
-          description: `${initiator} launched flash loan attack and made profit > $100000`,
-          alertId: "FLASHLOAN-ATTACK-WITH-HIGH-PROFIT",
-          severity: FindingSeverity.High,
-          type: FindingType.Exploit,
-          metadata: {
-            profit: (tokenUsdProfit + nativeUsdProfit).toFixed(2),
-            tokens: [asset],
-          },
-        }),
-      ]);
-
-      expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
-      expect(mockHelper.calculateTokenProfits).toHaveBeenCalledWith([], initiator);
-      expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([], initiator);
-      expect(mockHelper.calculateTokensUsdProfit).toHaveBeenCalledWith(
-        {
-          [asset]: tokenProfit,
+    expect(findings).toStrictEqual([
+      Finding.fromObject({
+        name: "Flashloan detected",
+        description: `${initiator} launched flash loan attack`,
+        alertId: "FLASHLOAN-ATTACK",
+        severity: FindingSeverity.Low,
+        type: FindingType.Exploit,
+        metadata: {
+          profit: (2000).toFixed(2),
+          tokens: [asset],
         },
-        chain
-      );
-      expect(mockHelper.calculateNativeUsdProfit).toHaveBeenCalledWith(nativeProfit, chain);
-    });
+      }),
+    ]);
 
-    it("returns a finding if there is a flashloan with low profit", async () => {
-      mockGetFlashloans.mockResolvedValueOnce([flashloan]);
-      mockTxEvent.filterLog.mockReturnValueOnce([]); // Mock transfers
-      mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(10000);
-      mockHelper.calculateTokenProfits.mockReturnValueOnce({ [asset]: tokenProfit });
-      mockHelper.calculateNativeProfit.mockReturnValueOnce(nativeProfit);
-      mockHelper.getTransactionReceipt.mockResolvedValueOnce({ gasUsed: 0 });
-      mockHelper.calculateTokensUsdProfit.mockResolvedValueOnce(1000);
-      mockHelper.calculateNativeUsdProfit.mockResolvedValueOnce(1000);
-      const findings = await handleTransaction(mockTxEvent);
-
-      expect(findings).toStrictEqual([
-        Finding.fromObject({
-          name: "Flashloan detected",
-          description: `${initiator} launched flash loan attack`,
-          alertId: "FLASHLOAN-ATTACK",
-          severity: FindingSeverity.Low,
-          type: FindingType.Exploit,
-          metadata: {
-            profit: (2000).toFixed(2),
-            tokens: [asset],
-          },
-        }),
-      ]);
-
-      expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
-      expect(mockHelper.calculateTokenProfits).toHaveBeenCalledWith([], initiator);
-      expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([], initiator);
-      expect(mockHelper.calculateTokensUsdProfit).toHaveBeenCalledWith(
-        {
-          [asset]: tokenProfit,
-        },
-        chain
-      );
-      expect(mockHelper.calculateNativeUsdProfit).toHaveBeenCalledWith(nativeProfit, chain);
-    });
-
-    it("returns a finding if there is a flashloan with high profit and low percentage", async () => {
-      mockGetFlashloans.mockResolvedValueOnce([flashloan]);
-      mockTxEvent.filterLog.mockReturnValueOnce([]); // Mock transfers
-      mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(100_000_000);
-      mockHelper.calculateTokenProfits.mockReturnValueOnce({ [asset]: tokenProfit });
-      mockHelper.calculateNativeProfit.mockReturnValueOnce(nativeProfit);
-      mockHelper.getTransactionReceipt.mockResolvedValueOnce({ gasUsed: 0 });
-      mockHelper.calculateTokensUsdProfit.mockResolvedValueOnce(tokenUsdProfit);
-      mockHelper.calculateNativeUsdProfit.mockResolvedValueOnce(highNativeUsdProfit);
-      const findings = await handleTransaction(mockTxEvent);
-
-      expect(findings).toStrictEqual([
-        Finding.fromObject({
-          name: "Flashloan detected",
-          description: `${initiator} launched flash loan attack and made profit > $500000`,
-          alertId: "FLASHLOAN-ATTACK-WITH-HIGH-PROFIT",
-          severity: FindingSeverity.High,
-          type: FindingType.Exploit,
-          metadata: {
-            profit: (tokenUsdProfit + highNativeUsdProfit).toFixed(2),
-            tokens: [asset],
-          },
-        }),
-      ]);
-
-      expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
-      expect(mockHelper.calculateTokenProfits).toHaveBeenCalledWith([], initiator);
-      expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([], initiator);
-      expect(mockHelper.calculateTokensUsdProfit).toHaveBeenCalledWith(
-        {
-          [asset]: tokenProfit,
-        },
-        chain
-      );
-      expect(mockHelper.calculateNativeUsdProfit).toHaveBeenCalledWith(nativeProfit, chain);
-    });
+    expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
+    expect(mockHelper.calculateTokenProfits).toHaveBeenCalledWith([diffMockTransferEvent], diffEndRecipient);
+    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([], initiator);
+    expect(mockHelper.calculateTokensUsdProfit).toHaveBeenCalledWith(
+      {
+        [asset]: tokenProfit,
+      },
+      chain
+    );
+    expect(mockHelper.calculateNativeUsdProfit).toHaveBeenCalledWith(nativeProfit, chain);
   });
 });

--- a/flashloan-detector/src/agent.spec.js
+++ b/flashloan-detector/src/agent.spec.js
@@ -43,7 +43,7 @@ const mockHelper = {
 
 describe("flashloan detector agent", () => {
   const mockProvider = {
-    getCode: jest.fn()
+    getCode: jest.fn(),
   };
 
   let initialize;
@@ -55,7 +55,7 @@ describe("flashloan detector agent", () => {
       to: initiator,
       value: 100,
       callType: "call",
-      input: "0x0"
+      input: "0x0",
     },
   };
 
@@ -65,9 +65,9 @@ describe("flashloan detector agent", () => {
       to: initiator,
       value: "0x0",
       callType: "call",
-      input: "0xa9059cbbDeFi"
-    }
-  }
+      input: "0xa9059cbbDeFi",
+    },
+  };
 
   const mockTransferEvent = {
     name: "Transfer",
@@ -106,7 +106,7 @@ describe("flashloan detector agent", () => {
       filterLog: jest.fn(),
       transaction: { gasPrice: 0 },
     };
-    
+
     mockGetFlashloans.mockResolvedValueOnce([flashloan]);
     mockHelper.calculateNativeProfit.mockReturnValueOnce(nativeProfit);
     mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(10000);
@@ -122,7 +122,7 @@ describe("flashloan detector agent", () => {
         severity: FindingSeverity.High,
         type: FindingType.Exploit,
         metadata: {
-          profit: (highNativeUsdProfit).toFixed(2),
+          profit: highNativeUsdProfit.toFixed(2),
           tokens: [],
         },
         labels: [
@@ -137,8 +137,6 @@ describe("flashloan detector agent", () => {
       }),
     ]);
 
-    
-
     expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
     expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([mockNativeTransferTrace], initiator);
     expect(mockHelper.calculateNativeUsdProfit).toHaveBeenCalledWith(nativeProfit, chain);
@@ -152,7 +150,7 @@ describe("flashloan detector agent", () => {
       filterLog: jest.fn(),
       transaction: { gasPrice: 0 },
     };
-    
+
     mockGetFlashloans.mockResolvedValueOnce([flashloan]);
     mockTxEvent.filterLog.mockReturnValueOnce([mockTransferEvent]);
     mockHelper.calculateTokenProfits.mockReturnValueOnce({ [asset]: tokenProfit });
@@ -169,7 +167,7 @@ describe("flashloan detector agent", () => {
         severity: FindingSeverity.High,
         type: FindingType.Exploit,
         metadata: {
-          profit: (hightokenUsdProfit).toFixed(2),
+          profit: hightokenUsdProfit.toFixed(2),
           tokens: [asset],
         },
         labels: [
@@ -219,7 +217,7 @@ describe("flashloan detector agent", () => {
         severity: FindingSeverity.High,
         type: FindingType.Exploit,
         metadata: {
-          profit: (veryHighTokenUsdProfit).toFixed(2),
+          profit: veryHighTokenUsdProfit.toFixed(2),
           tokens: [asset],
         },
         labels: [
@@ -281,7 +279,7 @@ describe("flashloan detector agent", () => {
         severity: FindingSeverity.Low,
         type: FindingType.Exploit,
         metadata: {
-          profit: (lowTokenUsdProfit).toFixed(2),
+          profit: lowTokenUsdProfit.toFixed(2),
           tokens: [asset],
         },
         labels: [
@@ -317,7 +315,7 @@ describe("flashloan detector agent", () => {
         to: diffEndRecipient,
         value: 100,
         callType: "call",
-        input: "0x0"
+        input: "0x0",
       },
     };
 
@@ -345,7 +343,7 @@ describe("flashloan detector agent", () => {
         severity: FindingSeverity.Low,
         type: FindingType.Exploit,
         metadata: {
-          profit: (lowNativeUsdProfit).toFixed(2),
+          profit: lowNativeUsdProfit.toFixed(2),
           tokens: [],
         },
         labels: [
@@ -361,7 +359,10 @@ describe("flashloan detector agent", () => {
     ]);
 
     expect(mockProvider.getCode).toHaveBeenCalledWith(diffEndRecipient);
-    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([mockNativeTransferDiffRecipientTrace], diffEndRecipient);
+    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith(
+      [mockNativeTransferDiffRecipientTrace],
+      diffEndRecipient
+    );
     expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
     expect(mockHelper.calculateNativeUsdProfit).toHaveBeenCalledWith(nativeProfit, chain);
   });

--- a/flashloan-detector/src/agent.spec.js
+++ b/flashloan-detector/src/agent.spec.js
@@ -11,10 +11,16 @@ const amount = ethers.utils.parseEther("100");
 const tokenProfit = ethers.utils.parseEther("10");
 const nativeProfit = ethers.utils.parseEther("1");
 
+const lowTokenUsdProfit = 1000;
+const lowNativeUsdProfit = 1000;
+
 const tokenUsdProfit = 100_000;
 const nativeUsdProfit = 100_000;
 
-const highNativeUsdProfit = 1_000_000;
+const highNativeUsdProfit = 200_000;
+const hightokenUsdProfit = 200_000;
+
+const veryHighTokenUsdProfit = 1_000_000;
 
 const flashloan = {
   asset,
@@ -36,25 +42,32 @@ const mockHelper = {
 };
 
 describe("flashloan detector agent", () => {
+  const mockProvider = {
+    getCode: jest.fn()
+  };
+
   let initialize;
   let handleTransaction;
 
-  const mockTrace = {
+  const mockNativeTransferTrace = {
     action: {
-      from: "0xabc",
+      from: contractCalled,
       to: initiator,
       value: 100,
-      callType: "call"
-    }
+      callType: "call",
+      input: "0x0"
+    },
   };
 
-  const mockTxEvent = {
-    from: initiator,
-    to: contractCalled,
-    traces: [mockTrace],
-    filterLog: jest.fn(),
-    transaction: { gasPrice: 0 },
-  };
+  const mockErc20TransferTrace = {
+    action: {
+      from: contractCalled,
+      to: initiator,
+      value: "0x0",
+      callType: "call",
+      input: "0xa9059cbbDeFi"
+    }
+  }
 
   const mockTransferEvent = {
     name: "Transfer",
@@ -67,25 +80,38 @@ describe("flashloan detector agent", () => {
   beforeAll(async () => {
     initialize = provideInitialize(mockHelper);
     await initialize();
-    handleTransaction = provideHandleTransaction(mockHelper, mockGetFlashloans);
+    handleTransaction = provideHandleTransaction(mockHelper, mockGetFlashloans, mockProvider);
   });
 
   it("returns empty findings if there are no flashloans", async () => {
+    const mockTxEvent = {
+      from: initiator,
+      to: contractCalled,
+      traces: [mockNativeTransferTrace],
+      filterLog: jest.fn(),
+      transaction: { gasPrice: 0 },
+    };
+
     mockGetFlashloans.mockResolvedValueOnce([]);
     const findings = await handleTransaction(mockTxEvent);
 
     expect(findings).toStrictEqual([]);
   });
 
-  it("returns a finding if there is a flashloan with high profit", async () => {
+  it("returns a finding if there is a flashloan with high native profit", async () => {
+    const mockTxEvent = {
+      from: initiator,
+      to: contractCalled,
+      traces: [mockNativeTransferTrace],
+      filterLog: jest.fn(),
+      transaction: { gasPrice: 0 },
+    };
+    
     mockGetFlashloans.mockResolvedValueOnce([flashloan]);
-    mockTxEvent.filterLog.mockReturnValueOnce([mockTransferEvent]);
-    mockHelper.calculateTokenProfits.mockReturnValueOnce({ [asset]: tokenProfit });
     mockHelper.calculateNativeProfit.mockReturnValueOnce(nativeProfit);
     mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(10000);
     mockHelper.getTransactionReceipt.mockResolvedValueOnce({ gasUsed: 0 });
-    mockHelper.calculateTokensUsdProfit.mockResolvedValueOnce(tokenUsdProfit);
-    mockHelper.calculateNativeUsdProfit.mockResolvedValueOnce(nativeUsdProfit);
+    mockHelper.calculateNativeUsdProfit.mockResolvedValueOnce(highNativeUsdProfit);
     const findings = await handleTransaction(mockTxEvent);
 
     expect(findings).toStrictEqual([
@@ -96,84 +122,93 @@ describe("flashloan detector agent", () => {
         severity: FindingSeverity.High,
         type: FindingType.Exploit,
         metadata: {
-          profit: (tokenUsdProfit + nativeUsdProfit).toFixed(2),
-          tokens: [asset],
+          profit: (highNativeUsdProfit).toFixed(2),
+          tokens: [],
         },
-        labels: [{
-          entityType: EntityType.Address,
-          entity: initiator,
-          labelType: LabelType.Attacker,
-          confidence: 90,
-          customValue: "Initiator of transaction"
-        }]
+        labels: [
+          {
+            entityType: EntityType.Address,
+            entity: initiator,
+            labelType: LabelType.Attacker,
+            confidence: 90,
+            customValue: "Initiator of transaction",
+          },
+        ],
       }),
     ]);
 
+    
+
     expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
-    expect(mockHelper.calculateTokenProfits).toHaveBeenCalledWith([mockTransferEvent], initiator);
-    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([mockTrace], initiator);
-    expect(mockHelper.calculateTokensUsdProfit).toHaveBeenCalledWith(
-      {
-        [asset]: tokenProfit,
-      },
-      chain
-    );
+    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([mockNativeTransferTrace], initiator);
     expect(mockHelper.calculateNativeUsdProfit).toHaveBeenCalledWith(nativeProfit, chain);
   });
 
-  it("returns a finding if there is a flashloan with low profit", async () => {
+  it("returns a finding if there is a flashloan with high token profit", async () => {
+    const mockTxEvent = {
+      from: initiator,
+      to: contractCalled,
+      traces: [mockErc20TransferTrace],
+      filterLog: jest.fn(),
+      transaction: { gasPrice: 0 },
+    };
+    
     mockGetFlashloans.mockResolvedValueOnce([flashloan]);
     mockTxEvent.filterLog.mockReturnValueOnce([mockTransferEvent]);
-    mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(10000);
     mockHelper.calculateTokenProfits.mockReturnValueOnce({ [asset]: tokenProfit });
-    mockHelper.calculateNativeProfit.mockReturnValueOnce(nativeProfit);
+    mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(10000);
     mockHelper.getTransactionReceipt.mockResolvedValueOnce({ gasUsed: 0 });
-    mockHelper.calculateTokensUsdProfit.mockResolvedValueOnce(1000);
-    mockHelper.calculateNativeUsdProfit.mockResolvedValueOnce(1000);
+    mockHelper.calculateTokensUsdProfit.mockResolvedValueOnce(hightokenUsdProfit);
     const findings = await handleTransaction(mockTxEvent);
 
     expect(findings).toStrictEqual([
       Finding.fromObject({
         name: "Flashloan detected",
-        description: `${initiator} launched flash loan attack`,
-        alertId: "FLASHLOAN-ATTACK",
-        severity: FindingSeverity.Low,
+        description: `${initiator} launched flash loan attack and made profit > $100000`,
+        alertId: "FLASHLOAN-ATTACK-WITH-HIGH-PROFIT",
+        severity: FindingSeverity.High,
         type: FindingType.Exploit,
         metadata: {
-          profit: (2000).toFixed(2),
+          profit: (hightokenUsdProfit).toFixed(2),
           tokens: [asset],
         },
-        labels: [{
-          entityType: EntityType.Address,
-          entity: initiator,
-          labelType: LabelType.Attacker,
-          confidence: 60,
-          customValue: "Initiator of transaction"
-        }]
+        labels: [
+          {
+            entityType: EntityType.Address,
+            entity: initiator,
+            labelType: LabelType.Attacker,
+            confidence: 90,
+            customValue: "Initiator of transaction",
+          },
+        ],
       }),
     ]);
 
     expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
     expect(mockHelper.calculateTokenProfits).toHaveBeenCalledWith([mockTransferEvent], initiator);
-    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([mockTrace], initiator);
     expect(mockHelper.calculateTokensUsdProfit).toHaveBeenCalledWith(
       {
         [asset]: tokenProfit,
       },
       chain
     );
-    expect(mockHelper.calculateNativeUsdProfit).toHaveBeenCalledWith(nativeProfit, chain);
   });
 
-  it("returns a finding if there is a flashloan with high profit and low percentage", async () => {
+  it("returns a finding if there is a flashloan with high token profit and high percentage", async () => {
+    const mockTxEvent = {
+      from: initiator,
+      to: contractCalled,
+      traces: [mockErc20TransferTrace],
+      filterLog: jest.fn(),
+      transaction: { gasPrice: 0 },
+    };
+
     mockGetFlashloans.mockResolvedValueOnce([flashloan]);
     mockTxEvent.filterLog.mockReturnValueOnce([mockTransferEvent]);
-    mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(100_000_000);
     mockHelper.calculateTokenProfits.mockReturnValueOnce({ [asset]: tokenProfit });
-    mockHelper.calculateNativeProfit.mockReturnValueOnce(nativeProfit);
+    mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(100_000_000);
     mockHelper.getTransactionReceipt.mockResolvedValueOnce({ gasUsed: 0 });
-    mockHelper.calculateTokensUsdProfit.mockResolvedValueOnce(tokenUsdProfit);
-    mockHelper.calculateNativeUsdProfit.mockResolvedValueOnce(highNativeUsdProfit);
+    mockHelper.calculateTokensUsdProfit.mockResolvedValueOnce(veryHighTokenUsdProfit);
     const findings = await handleTransaction(mockTxEvent);
 
     expect(findings).toStrictEqual([
@@ -184,32 +219,32 @@ describe("flashloan detector agent", () => {
         severity: FindingSeverity.High,
         type: FindingType.Exploit,
         metadata: {
-          profit: (tokenUsdProfit + highNativeUsdProfit).toFixed(2),
+          profit: (veryHighTokenUsdProfit).toFixed(2),
           tokens: [asset],
         },
-        labels: [{
-          entityType: EntityType.Address,
-          entity: initiator,
-          labelType: LabelType.Attacker,
-          confidence: 90,
-          customValue: "Initiator of transaction"
-        }]
+        labels: [
+          {
+            entityType: EntityType.Address,
+            entity: initiator,
+            labelType: LabelType.Attacker,
+            confidence: 90,
+            customValue: "Initiator of transaction",
+          },
+        ],
       }),
     ]);
 
     expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
     expect(mockHelper.calculateTokenProfits).toHaveBeenCalledWith([mockTransferEvent], initiator);
-    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([mockTrace], initiator);
     expect(mockHelper.calculateTokensUsdProfit).toHaveBeenCalledWith(
       {
         [asset]: tokenProfit,
       },
       chain
     );
-    expect(mockHelper.calculateNativeUsdProfit).toHaveBeenCalledWith(nativeProfit, chain);
   });
 
-  it("returns a finding if there is a flashloan with low profit with a different end recipient", async () => {
+  it("returns a finding if there is a flashloan with low token profit with a different end recipient", async () => {
     const diffEndRecipient = "0xdst";
     const diffMockTransferEvent = {
       name: "Transfer",
@@ -219,14 +254,23 @@ describe("flashloan detector agent", () => {
       },
     };
 
+    const mockTxEvent = {
+      from: initiator,
+      to: contractCalled,
+      traces: [mockErc20TransferTrace],
+      filterLog: jest.fn(),
+      transaction: { gasPrice: 0 },
+    };
+
     mockGetFlashloans.mockResolvedValueOnce([flashloan]);
     mockTxEvent.filterLog.mockReturnValueOnce([diffMockTransferEvent]);
-    mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(10000);
+    mockProvider.getCode.mockReturnValueOnce("0x");
     mockHelper.calculateTokenProfits.mockReturnValueOnce({ [asset]: tokenProfit });
-    mockHelper.calculateNativeProfit.mockReturnValueOnce(nativeProfit);
+    mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(10000);
+    // mockHelper.calculateNativeProfit.mockReturnValueOnce(nativeProfit);
     mockHelper.getTransactionReceipt.mockResolvedValueOnce({ gasUsed: 0 });
-    mockHelper.calculateTokensUsdProfit.mockResolvedValueOnce(1000);
-    mockHelper.calculateNativeUsdProfit.mockResolvedValueOnce(1000);
+    mockHelper.calculateTokensUsdProfit.mockResolvedValueOnce(lowTokenUsdProfit);
+    // mockHelper.calculateNativeUsdProfit.mockResolvedValueOnce(1000);
     const findings = await handleTransaction(mockTxEvent);
 
     expect(findings).toStrictEqual([
@@ -237,28 +281,88 @@ describe("flashloan detector agent", () => {
         severity: FindingSeverity.Low,
         type: FindingType.Exploit,
         metadata: {
-          profit: (2000).toFixed(2),
+          profit: (lowTokenUsdProfit).toFixed(2),
           tokens: [asset],
         },
-        labels: [{
-          entityType: EntityType.Address,
-          entity: initiator,
-          labelType: LabelType.Attacker,
-          confidence: 60,
-          customValue: "Initiator of transaction"
-        }]
+        labels: [
+          {
+            entityType: EntityType.Address,
+            entity: initiator,
+            labelType: LabelType.Attacker,
+            confidence: 60,
+            customValue: "Initiator of transaction",
+          },
+        ],
       }),
     ]);
 
-    expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
+    expect(mockProvider.getCode).toHaveBeenCalledWith(diffEndRecipient);
     expect(mockHelper.calculateTokenProfits).toHaveBeenCalledWith([diffMockTransferEvent], diffEndRecipient);
-    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([mockTrace], initiator);
+    expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
+    // expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([mockTrace], initiator);
     expect(mockHelper.calculateTokensUsdProfit).toHaveBeenCalledWith(
       {
         [asset]: tokenProfit,
       },
       chain
     );
+    // expect(mockHelper.calculateNativeUsdProfit).toHaveBeenCalledWith(nativeProfit, chain);
+  });
+
+  it("returns a finding if there is a flashloan with low native profit with a different end recipient", async () => {
+    const diffEndRecipient = "0xdst";
+    const mockNativeTransferDiffRecipientTrace = {
+      action: {
+        from: contractCalled,
+        to: diffEndRecipient,
+        value: 100,
+        callType: "call",
+        input: "0x0"
+      },
+    };
+
+    const mockTxEvent = {
+      from: initiator,
+      to: contractCalled,
+      traces: [mockNativeTransferDiffRecipientTrace],
+      filterLog: jest.fn(),
+      transaction: { gasPrice: 0 },
+    };
+
+    mockGetFlashloans.mockResolvedValueOnce([flashloan]);
+    mockProvider.getCode.mockReturnValueOnce("0x");
+    mockHelper.calculateNativeProfit.mockReturnValueOnce(nativeProfit);
+    mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(10000);
+    mockHelper.getTransactionReceipt.mockResolvedValueOnce({ gasUsed: 0 });
+    mockHelper.calculateNativeUsdProfit.mockResolvedValueOnce(lowNativeUsdProfit);
+    const findings = await handleTransaction(mockTxEvent);
+
+    expect(findings).toStrictEqual([
+      Finding.fromObject({
+        name: "Flashloan detected",
+        description: `${initiator} launched flash loan attack`,
+        alertId: "FLASHLOAN-ATTACK",
+        severity: FindingSeverity.Low,
+        type: FindingType.Exploit,
+        metadata: {
+          profit: (lowNativeUsdProfit).toFixed(2),
+          tokens: [],
+        },
+        labels: [
+          {
+            entityType: EntityType.Address,
+            entity: initiator,
+            labelType: LabelType.Attacker,
+            confidence: 60,
+            customValue: "Initiator of transaction",
+          },
+        ],
+      }),
+    ]);
+
+    expect(mockProvider.getCode).toHaveBeenCalledWith(diffEndRecipient);
+    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([mockNativeTransferDiffRecipientTrace], diffEndRecipient);
+    expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
     expect(mockHelper.calculateNativeUsdProfit).toHaveBeenCalledWith(nativeProfit, chain);
   });
 });

--- a/flashloan-detector/src/agent.spec.js
+++ b/flashloan-detector/src/agent.spec.js
@@ -1,4 +1,4 @@
-const { FindingType, FindingSeverity, Finding, ethers } = require("forta-agent");
+const { FindingType, FindingSeverity, Finding, ethers, LabelType, EntityType } = require("forta-agent");
 const { provideHandleTransaction, provideInitialize } = require("./agent");
 
 const asset = "0xasset";
@@ -99,6 +99,13 @@ describe("flashloan detector agent", () => {
           profit: (tokenUsdProfit + nativeUsdProfit).toFixed(2),
           tokens: [asset],
         },
+        labels: [{
+          entityType: EntityType.Address,
+          entity: initiator,
+          labelType: LabelType.Attacker,
+          confidence: 90,
+          customValue: "Initiator of transaction"
+        }]
       }),
     ]);
 
@@ -136,6 +143,13 @@ describe("flashloan detector agent", () => {
           profit: (2000).toFixed(2),
           tokens: [asset],
         },
+        labels: [{
+          entityType: EntityType.Address,
+          entity: initiator,
+          labelType: LabelType.Attacker,
+          confidence: 60,
+          customValue: "Initiator of transaction"
+        }]
       }),
     ]);
 
@@ -173,6 +187,13 @@ describe("flashloan detector agent", () => {
           profit: (tokenUsdProfit + highNativeUsdProfit).toFixed(2),
           tokens: [asset],
         },
+        labels: [{
+          entityType: EntityType.Address,
+          entity: initiator,
+          labelType: LabelType.Attacker,
+          confidence: 90,
+          customValue: "Initiator of transaction"
+        }]
       }),
     ]);
 
@@ -219,12 +240,19 @@ describe("flashloan detector agent", () => {
           profit: (2000).toFixed(2),
           tokens: [asset],
         },
+        labels: [{
+          entityType: EntityType.Address,
+          entity: initiator,
+          labelType: LabelType.Attacker,
+          confidence: 60,
+          customValue: "Initiator of transaction"
+        }]
       }),
     ]);
 
     expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
     expect(mockHelper.calculateTokenProfits).toHaveBeenCalledWith([diffMockTransferEvent], diffEndRecipient);
-    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([], initiator);
+    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([mockTrace], initiator);
     expect(mockHelper.calculateTokensUsdProfit).toHaveBeenCalledWith(
       {
         [asset]: tokenProfit,

--- a/flashloan-detector/src/agent.spec.js
+++ b/flashloan-detector/src/agent.spec.js
@@ -39,10 +39,19 @@ describe("flashloan detector agent", () => {
   let initialize;
   let handleTransaction;
 
+  const mockTrace = {
+    action: {
+      from: "0xabc",
+      to: initiator,
+      value: 100,
+      callType: "call"
+    }
+  };
+
   const mockTxEvent = {
     from: initiator,
     to: contractCalled,
-    traces: [],
+    traces: [mockTrace],
     filterLog: jest.fn(),
     transaction: { gasPrice: 0 },
   };
@@ -51,8 +60,8 @@ describe("flashloan detector agent", () => {
     name: "Transfer",
     args: {
       src: contractCalled,
-      dst: initiator
-    }
+      dst: initiator,
+    },
   };
 
   beforeAll(async () => {
@@ -71,9 +80,9 @@ describe("flashloan detector agent", () => {
   it("returns a finding if there is a flashloan with high profit", async () => {
     mockGetFlashloans.mockResolvedValueOnce([flashloan]);
     mockTxEvent.filterLog.mockReturnValueOnce([mockTransferEvent]);
-    mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(10000);
     mockHelper.calculateTokenProfits.mockReturnValueOnce({ [asset]: tokenProfit });
     mockHelper.calculateNativeProfit.mockReturnValueOnce(nativeProfit);
+    mockHelper.calculateBorrowedAmount.mockResolvedValueOnce(10000);
     mockHelper.getTransactionReceipt.mockResolvedValueOnce({ gasUsed: 0 });
     mockHelper.calculateTokensUsdProfit.mockResolvedValueOnce(tokenUsdProfit);
     mockHelper.calculateNativeUsdProfit.mockResolvedValueOnce(nativeUsdProfit);
@@ -95,7 +104,7 @@ describe("flashloan detector agent", () => {
 
     expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
     expect(mockHelper.calculateTokenProfits).toHaveBeenCalledWith([mockTransferEvent], initiator);
-    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([], initiator);
+    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([mockTrace], initiator);
     expect(mockHelper.calculateTokensUsdProfit).toHaveBeenCalledWith(
       {
         [asset]: tokenProfit,
@@ -132,7 +141,7 @@ describe("flashloan detector agent", () => {
 
     expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
     expect(mockHelper.calculateTokenProfits).toHaveBeenCalledWith([mockTransferEvent], initiator);
-    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([], initiator);
+    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([mockTrace], initiator);
     expect(mockHelper.calculateTokensUsdProfit).toHaveBeenCalledWith(
       {
         [asset]: tokenProfit,
@@ -169,7 +178,7 @@ describe("flashloan detector agent", () => {
 
     expect(mockHelper.calculateBorrowedAmount).toHaveBeenCalledWith(asset, amount, chain);
     expect(mockHelper.calculateTokenProfits).toHaveBeenCalledWith([mockTransferEvent], initiator);
-    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([], initiator);
+    expect(mockHelper.calculateNativeProfit).toHaveBeenCalledWith([mockTrace], initiator);
     expect(mockHelper.calculateTokensUsdProfit).toHaveBeenCalledWith(
       {
         [asset]: tokenProfit,
@@ -185,8 +194,8 @@ describe("flashloan detector agent", () => {
       name: "Transfer",
       args: {
         src: contractCalled,
-        dst: diffEndRecipient
-      }
+        dst: diffEndRecipient,
+      },
     };
 
     mockGetFlashloans.mockResolvedValueOnce([flashloan]);

--- a/flashloan-detector/src/detectors/balancer-detector.js
+++ b/flashloan-detector/src/detectors/balancer-detector.js
@@ -1,4 +1,5 @@
-const balancerFlashloanSig = "event FlashLoan(address indexed receiver, address indexed token, uint256 amount, uint256 feeAmount)";
+const balancerFlashloanSig =
+  "event FlashLoan(address indexed receiver, address indexed token, uint256 amount, uint256 feeAmount)";
 
 module.exports = {
   getBalancerFlashloan: (txEvent) => {

--- a/flashloan-detector/src/detectors/balancer-detector.js
+++ b/flashloan-detector/src/detectors/balancer-detector.js
@@ -1,0 +1,18 @@
+const balancerFlashloanSig = "event FlashLoan(address indexed receiver, address indexed token, uint256 amount, uint256 feeAmount)";
+
+module.exports = {
+  getBalancerFlashloan: (txEvent) => {
+    const flashloans = [];
+    const events = txEvent.filterLog(balancerFlashloanSig);
+
+    events.forEach((event) => {
+      const { token, amount, receiver } = event.args;
+      flashloans.push({
+        asset: token.toLowerCase(),
+        amount,
+        account: receiver.toLowerCase(),
+      });
+    });
+    return flashloans;
+  },
+};

--- a/flashloan-detector/src/detectors/dodo-detector.js
+++ b/flashloan-detector/src/detectors/dodo-detector.js
@@ -1,6 +1,7 @@
 const { ethers, getEthersProvider } = require("forta-agent");
 
-const dodoFlashloanAbi = "event DODOFlashLoan (address borrower, address assetTo, uint256 baseAmount, uint256 quoteAmount)";
+const dodoFlashloanAbi =
+  "event DODOFlashLoan (address borrower, address assetTo, uint256 baseAmount, uint256 quoteAmount)";
 
 const dodoPoolAbi = [
   "function _BASE_TOKEN_ public view returns (address)",

--- a/flashloan-detector/src/detectors/dodo-detector.js
+++ b/flashloan-detector/src/detectors/dodo-detector.js
@@ -1,6 +1,6 @@
 const { ethers, getEthersProvider } = require("forta-agent");
 
-const dodoFlashloanAbi = "DODOFlashLoan (address borrower, address assetTo, uint256 baseAmount, uint256 quoteAmount)";
+const dodoFlashloanAbi = "event DODOFlashLoan (address borrower, address assetTo, uint256 baseAmount, uint256 quoteAmount)";
 
 const dodoPoolAbi = [
   "function _BASE_TOKEN_ public view returns (address)",

--- a/flashloan-detector/src/detectors/dodo-detector.js
+++ b/flashloan-detector/src/detectors/dodo-detector.js
@@ -4,8 +4,8 @@ const dodoFlashloanAbi =
   "event DODOFlashLoan (address borrower, address assetTo, uint256 baseAmount, uint256 quoteAmount)";
 
 const dodoPoolAbi = [
-  "function _BASE_TOKEN_ public view returns (address)",
-  "function _QUOTE_TOKEN_ public view returns (address)",
+  "function _BASE_TOKEN_() public view returns (address)",
+  "function _QUOTE_TOKEN_(0) public view returns (address)",
 ];
 
 module.exports = {

--- a/flashloan-detector/src/detectors/dodo-detector.js
+++ b/flashloan-detector/src/detectors/dodo-detector.js
@@ -1,0 +1,44 @@
+const { ethers, getEthersProvider } = require("forta-agent");
+
+const dodoFlashloanAbi = "DODOFlashLoan (address borrower, address assetTo, uint256 baseAmount, uint256 quoteAmount)";
+
+const dodoPoolAbi = [
+    "function _BASE_TOKEN_ public view returns (address)",
+    "function _QUOTE_TOKEN_ public view returns (address)"
+];
+
+module.exports = {
+    getDodoFlashloan: (txEvent) => {
+        const flashloans = [];
+        const events = txEvent.filterLog(dodoFlashloanAbi);
+
+        events.forEach(async (event) => {
+            const { address } = event;
+            const { assetTo, baseAmount, quoteAmount } = event.args;
+
+            const contract = new ethers.Contract(address, dodoPoolAbi, getEthersProvider());
+
+            if(quoteAmount.gt(ethers.constants.Zero)) {
+                const quoteToken = await contract._QUOTE_TOKEN_();
+
+                flashloans.push({
+                    asset: quoteToken.toLowerCase(),
+                    amount: quoteAmount,
+                    account: assetTo.toLowerCase()
+                });
+            };
+            
+            if(baseAmount.gt(ethers.constants.Zero)) {
+                const baseToken = await contract._BASE_TOKEN_();
+
+                flashloans.push({
+                    asset: baseToken.toLowerCase(),
+                    amount: baseAmount,
+                    account: assetTo.toLowerCase()
+                });
+            };
+
+        });
+        return flashloans;
+    },
+  };

--- a/flashloan-detector/src/detectors/dodo-detector.js
+++ b/flashloan-detector/src/detectors/dodo-detector.js
@@ -5,7 +5,7 @@ const dodoFlashloanAbi =
 
 const dodoPoolAbi = [
   "function _BASE_TOKEN_() public view returns (address)",
-  "function _QUOTE_TOKEN_(0) public view returns (address)",
+  "function _QUOTE_TOKEN_() public view returns (address)",
 ];
 
 module.exports = {

--- a/flashloan-detector/src/detectors/dodo-detector.js
+++ b/flashloan-detector/src/detectors/dodo-detector.js
@@ -3,40 +3,40 @@ const { ethers, getEthersProvider } = require("forta-agent");
 const dodoFlashloanAbi = "DODOFlashLoan (address borrower, address assetTo, uint256 baseAmount, uint256 quoteAmount)";
 
 const dodoPoolAbi = [
-    "function _BASE_TOKEN_ public view returns (address)",
-    "function _QUOTE_TOKEN_ public view returns (address)"
+  "function _BASE_TOKEN_ public view returns (address)",
+  "function _QUOTE_TOKEN_ public view returns (address)",
 ];
 
 module.exports = {
-    getDodoFlashloan: async (txEvent) => {
-        const events = txEvent.filterLog(dodoFlashloanAbi);
+  getDodoFlashloan: async (txEvent) => {
+    const events = txEvent.filterLog(dodoFlashloanAbi);
 
-        const flashloans = await Promise.all(
-            events.map(async (event) => {
-                const { address } = event;
-                const { assetTo, baseAmount, quoteAmount } = event.args;
+    const flashloans = await Promise.all(
+      events.map(async (event) => {
+        const { address } = event;
+        const { assetTo, baseAmount, quoteAmount } = event.args;
 
-                const contract = new ethers.Contract(address, dodoPoolAbi, getEthersProvider());
+        const contract = new ethers.Contract(address, dodoPoolAbi, getEthersProvider());
 
-                if(quoteAmount.gt(ethers.constants.Zero)) {
-                    const quoteToken = await contract._QUOTE_TOKEN_();
-    
-                    return {
-                        asset: quoteToken.toLowerCase(),
-                        amount: quoteAmount,
-                        account: assetTo.toLowerCase()
-                    };
-                } else if(baseAmount.gt(ethers.constants.Zero)) {
-                    const baseToken = await contract._BASE_TOKEN_();
-    
-                    return {
-                        asset: baseToken.toLowerCase(),
-                        amount: baseAmount,
-                        account: assetTo.toLowerCase()
-                    };
-                };
-            })
-        );
-        return flashloans;
-    },
-  };
+        if (quoteAmount.gt(ethers.constants.Zero)) {
+          const quoteToken = await contract._QUOTE_TOKEN_();
+
+          return {
+            asset: quoteToken.toLowerCase(),
+            amount: quoteAmount,
+            account: assetTo.toLowerCase(),
+          };
+        } else if (baseAmount.gt(ethers.constants.Zero)) {
+          const baseToken = await contract._BASE_TOKEN_();
+
+          return {
+            asset: baseToken.toLowerCase(),
+            amount: baseAmount,
+            account: assetTo.toLowerCase(),
+          };
+        }
+      })
+    );
+    return flashloans;
+  },
+};

--- a/flashloan-detector/src/flashloan-detector.js
+++ b/flashloan-detector/src/flashloan-detector.js
@@ -4,6 +4,7 @@ const { getDydxFlashloan } = require("./detectors/dydx-detector");
 const { getEulerFlashloan } = require("./detectors/euler-detector");
 const { getIronBankFlashloan } = require("./detectors/iron-bank-detector");
 const { getMakerFlashloan } = require("./detectors/maker-detector");
+const { getBalancerFlashloan } = require("./detectors/balancer-detector");
 const { getUniswapV2Flashloan } = require("./detectors/uniswap-v2-detector");
 const { getUniswapV3Flashloan } = require("./detectors/uniswap-v3-detector");
 
@@ -19,6 +20,7 @@ module.exports = {
     const makerFlashloans = getMakerFlashloan(txEvent);
     const uniswapV2Flashloans = await getUniswapV2Flashloan(txEvent);
     const uniswapV3Flashloans = await getUniswapV3Flashloan(txEvent);
+    const balancerFlashloans = getBalancerFlashloan(txEvent);
 
     flashloanProtocols.push(
       ...aaveV2Flashloans,
@@ -28,7 +30,8 @@ module.exports = {
       ...ironBankFlashloans,
       ...makerFlashloans,
       ...uniswapV2Flashloans,
-      ...uniswapV3Flashloans
+      ...uniswapV3Flashloans,
+      ...balancerFlashloans
     );
 
     return flashloanProtocols;

--- a/flashloan-detector/src/flashloan-detector.js
+++ b/flashloan-detector/src/flashloan-detector.js
@@ -22,7 +22,7 @@ module.exports = {
     const uniswapV2Flashloans = await getUniswapV2Flashloan(txEvent);
     const uniswapV3Flashloans = await getUniswapV3Flashloan(txEvent);
     const balancerFlashloans = getBalancerFlashloan(txEvent);
-    const dodoFlashloans = getDodoFlashloan(txEvent);
+    const dodoFlashloans = await getDodoFlashloan(txEvent);
 
     flashloanProtocols.push(
       ...aaveV2Flashloans,

--- a/flashloan-detector/src/flashloan-detector.js
+++ b/flashloan-detector/src/flashloan-detector.js
@@ -7,6 +7,7 @@ const { getMakerFlashloan } = require("./detectors/maker-detector");
 const { getBalancerFlashloan } = require("./detectors/balancer-detector");
 const { getUniswapV2Flashloan } = require("./detectors/uniswap-v2-detector");
 const { getUniswapV3Flashloan } = require("./detectors/uniswap-v3-detector");
+const { getDodoFlashloan } = require("./detectors/dodo-detector");
 
 module.exports = {
   // Returns an array of protocols from which a flashloan was taken
@@ -21,6 +22,7 @@ module.exports = {
     const uniswapV2Flashloans = await getUniswapV2Flashloan(txEvent);
     const uniswapV3Flashloans = await getUniswapV3Flashloan(txEvent);
     const balancerFlashloans = getBalancerFlashloan(txEvent);
+    const dodoFlashloans = getDodoFlashloan(txEvent);
 
     flashloanProtocols.push(
       ...aaveV2Flashloans,
@@ -31,7 +33,8 @@ module.exports = {
       ...makerFlashloans,
       ...uniswapV2Flashloans,
       ...uniswapV3Flashloans,
-      ...balancerFlashloans
+      ...balancerFlashloans,
+      ...dodoFlashloans
     );
 
     return flashloanProtocols;

--- a/flashloan-detector/src/flashloan-detector.spec.js
+++ b/flashloan-detector/src/flashloan-detector.spec.js
@@ -18,6 +18,7 @@ jest.mock("forta-agent", () => {
         getMarket: () => [asset],
         underlying: () => asset,
         token0: () => asset,
+        _QUOTE_TOKEN_: () => asset
       })),
     },
   };
@@ -117,8 +118,13 @@ const mockUniswapV3FunctionCall = {
   },
 };
 
-const mockBalancererEvent = {
+const mockBalancerEvent = {
   args: { token: asset, amount, receiver: account },
+};
+
+const mockDodoFlashLoanEvent = {
+  address: "0xdefi",
+  args: { baseAmount: ethers.constants.Zero, quoteAmount: amount, assetTo: account },
 };
 
 describe("FlashloanDetector library", () => {
@@ -155,14 +161,17 @@ describe("FlashloanDetector library", () => {
       mockTxEvent.filterLog.mockReturnValueOnce([mockMakerEvent]);
       mockTxEvent.filterFunction.mockReturnValueOnce([mockUniswapV2FunctionCall]);
       mockTxEvent.filterFunction.mockReturnValueOnce([mockUniswapV3FunctionCall]);
-      mockTxEvent.filterLog.mockReturnValueOnce([mockBalancererEvent]);
+      mockTxEvent.filterLog.mockReturnValueOnce([mockBalancerEvent]);
+      mockTxEvent.filterLog.mockReturnValueOnce([mockDodoFlashLoanEvent]);
       const flashloans = await getFlashloans(mockTxEvent);
 
       const expectedFlashloanData = { account, amount, asset };
       const expectedArray = [];
 
-      // 8 flashloans: aaveV2, aaveV3, dydx, euler, iron bank, maker, uniswap V2, uniswap V3, balancer
-      for (let i = 0; i < 9; i++) {
+      // 10 flashloans:
+      // 1. aaveV2, 2. aaveV3, 3. dydx, 4. euler, 5. iron bank
+      // 6. maker, 7. uniswap V2, 8. uniswap V3, 9. balancer, 10. DODO
+      for (let i = 0; i < 10; i++) {
         expectedArray.push(expectedFlashloanData);
       }
 

--- a/flashloan-detector/src/flashloan-detector.spec.js
+++ b/flashloan-detector/src/flashloan-detector.spec.js
@@ -18,7 +18,7 @@ jest.mock("forta-agent", () => {
         getMarket: () => [asset],
         underlying: () => asset,
         token0: () => asset,
-        _QUOTE_TOKEN_: () => asset
+        _QUOTE_TOKEN_: () => asset,
       })),
     },
   };

--- a/flashloan-detector/src/flashloan-detector.spec.js
+++ b/flashloan-detector/src/flashloan-detector.spec.js
@@ -117,6 +117,10 @@ const mockUniswapV3FunctionCall = {
   },
 };
 
+const mockBalancererEvent = {
+  args: { token: asset, amount, receiver: account },
+};
+
 describe("FlashloanDetector library", () => {
   const mockTxEvent = {
     filterLog: jest.fn(),
@@ -151,13 +155,14 @@ describe("FlashloanDetector library", () => {
       mockTxEvent.filterLog.mockReturnValueOnce([mockMakerEvent]);
       mockTxEvent.filterFunction.mockReturnValueOnce([mockUniswapV2FunctionCall]);
       mockTxEvent.filterFunction.mockReturnValueOnce([mockUniswapV3FunctionCall]);
+      mockTxEvent.filterLog.mockReturnValueOnce([mockBalancererEvent]);
       const flashloans = await getFlashloans(mockTxEvent);
 
       const expectedFlashloanData = { account, amount, asset };
       const expectedArray = [];
 
-      // 7 flashloans: aaveV2, aaveV3, dydx, euler, iron bank, maker, uniswap V2, uniswap V3
-      for (let i = 0; i < 8; i++) {
+      // 8 flashloans: aaveV2, aaveV3, dydx, euler, iron bank, maker, uniswap V2, uniswap V3, balancer
+      for (let i = 0; i < 9; i++) {
         expectedArray.push(expectedFlashloanData);
       }
 

--- a/flashloan-detector/src/helper.js
+++ b/flashloan-detector/src/helper.js
@@ -68,6 +68,7 @@ module.exports = {
     await ethcallProvider.init();
     const { chainId } = await getEthersProvider().getNetwork();
     return {
+      chainId,
       chain: getChainByChainId(chainId),
       nativeToken: getNativeTokenByChainId(chainId),
     };


### PR DESCRIPTION
* Update to track the profit of the end recipient instead of the transaction initiator via looping through transaction traces in reverse
* Update bot tests to check for the destination address of a ERC20 `Transfer` event and native coin transfers
* Add new test for case when end recipient is not the transaction initiator
* Update tests to properly utilize traces
* Add `labels` property to findings
* Add coverage for Balancer and DODO flashloans