### PR TITLE
Asset Drained 03.03 - Update

### DIFF
--- a/asset-drained/README.md
+++ b/asset-drained/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This bot detects if an asset is fully drained from a contract within a block. It monitors ERC20 and native tokens transfers from contracts and raises an alert when a contract, having a non-zero token balance in the recent past (10 mins ago), now has 0.
+This bot detects if a contract has had 99% or more of its assets drained within a block. It monitors ERC20 and native tokens transfers from contracts and raises an alert when a contract has its balance decrease by 99% or more from one block to the next.
 
 ## Supported Chains
 
@@ -17,7 +17,7 @@ This bot detects if an asset is fully drained from a contract within a block. It
 ## Alerts
 
 - ASSET-DRAINED
-  - Fired when an asset is fully drained from a contract
+  - Fired when a contract has 99% or more of its assets drained
   - Severity is always set to "high"
   - Type is always set to "suspicious"
   - Metadata:

--- a/asset-drained/README.md
+++ b/asset-drained/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This bot detects if a contract has had 99% or more of its assets drained within a block. It monitors ERC20 and native tokens transfers from contracts and raises an alert when a contract has its balance decrease by 99% or more from one block to the next.
+This bot detects if a contract has had 99% or more of one of its assets drained within a block. It monitors ERC20 and native tokens transfers from contracts and raises an alert when a contract has its balance decreased by 99% or more from one block to the next.
 
 ## Supported Chains
 
@@ -17,7 +17,7 @@ This bot detects if a contract has had 99% or more of its assets drained within 
 ## Alerts
 
 - ASSET-DRAINED
-  - Fired when a contract has 99% or more of its assets drained
+  - Fired when a contract has had 99% or more of one of its assets drained
   - Severity is always set to "high"
   - Type is always set to "suspicious"
   - Metadata:

--- a/asset-drained/package-lock.json
+++ b/asset-drained/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "asset-drained",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "asset-drained",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "dependencies": {
         "forta-agent": "0.1.9",
         "forta-agent-tools": "^3.1.2",

--- a/asset-drained/package-lock.json
+++ b/asset-drained/package-lock.json
@@ -3904,9 +3904,9 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -8177,9 +8177,9 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
     },
     "jsonc": {
       "version": "2.0.0",

--- a/asset-drained/package.json
+++ b/asset-drained/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset-drained",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Detects if an asset is fully drained from a contract",
   "repository": "https://github.com/NethermindEth/forta-starter-kits/tree/main/asset-drained",
   "chainIds": [

--- a/asset-drained/src/agent.js
+++ b/asset-drained/src/agent.js
@@ -129,8 +129,8 @@ const handleBlock = async (blockEvent) => {
   });
 
   // Only process addresses with fully drained assets
-  const balances = await ethcallProvider.all(balanceCalls, blockNumber - 1);
-  transfers = transfers.filter((_, i) => balances[1][i].eq(ZERO));
+  const balances = await ethcallProvider.tryAll(balanceCalls, blockNumber - 1);
+  transfers = transfers.filter((_, i) => balances[i]["success"] && balances[i]["returnData"].eq(ZERO));
 
   // Filter out events to EOAs
   transfers = await Promise.all(

--- a/asset-drained/src/agent.js
+++ b/asset-drained/src/agent.js
@@ -107,7 +107,9 @@ const handleBlock = async (blockEvent) => {
   const { blockNumber } = blockEvent;
   const findings = [];
 
-  let transfers = Object.values(transfersObj).filter((t) => t.address !== ethers.constants.AddressZero);
+  let transfers = Object.values(transfersObj)
+    .filter((t) => t.value.lt(ZERO))
+    .filter((t) => t.address !== ethers.constants.AddressZero);
   if (transfers.length === 0) return [];
 
   const st = new Date();

--- a/asset-drained/src/agent.js
+++ b/asset-drained/src/agent.js
@@ -107,6 +107,7 @@ const handleBlock = async (blockEvent) => {
   const { blockNumber } = blockEvent;
   const findings = [];
 
+  // Only process addresses that had more funds withdrawn than deposited
   let transfers = Object.values(transfersObj)
     .filter((t) => t.value.lt(ZERO))
     .filter((t) => t.address !== ethers.constants.AddressZero);

--- a/asset-drained/src/agent.js
+++ b/asset-drained/src/agent.js
@@ -107,8 +107,7 @@ const handleBlock = async (blockEvent) => {
   const { blockNumber } = blockEvent;
   const findings = [];
 
-  let transfers = Object.values(transfersObj)
-    .filter((t) => t.address !== ethers.constants.AddressZero);
+  let transfers = Object.values(transfersObj).filter((t) => t.address !== ethers.constants.AddressZero);
   if (transfers.length === 0) return [];
 
   const st = new Date();
@@ -146,9 +145,7 @@ const handleBlock = async (blockEvent) => {
   );
   transfers = transfers.filter((e) => !!e);
 
-  const symbols = await Promise.all([
-    ...transfers.map((event) => getAssetSymbol(event.asset, cachedAssetSymbols))
-  ]);
+  const symbols = await Promise.all([...transfers.map((event) => getAssetSymbol(event.asset, cachedAssetSymbols))]);
 
   symbols.forEach((s, i) => {
     transfers[i].symbol = s;

--- a/asset-drained/src/agent.spec.js
+++ b/asset-drained/src/agent.spec.js
@@ -1,10 +1,21 @@
-const mockEthcallProviderAll = jest.fn();
+const mockEthcallProviderTryAll = jest.fn();
 const mockBalanceOf = jest.fn();
 
 const { FindingType, FindingSeverity, Finding, ethers } = require("forta-agent");
-const { hashCode } = require("./helper");
 const { createAddress } = require("forta-agent-tools");
 const { handleTransaction, handleBlock, getTransfersObj } = require("./agent");
+
+function hashCode(address, asset) {
+  const str = address + asset;
+  let hash = 0;
+  if (str.length === 0) return hash;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash &= hash; // Convert to 32bit integer
+  }
+  return hash;
+}
 
 const asset = createAddress("0x01");
 const address1 = createAddress("0x02");
@@ -24,7 +35,7 @@ jest.mock("forta-agent-tools", () => {
   return {
     ...original,
     MulticallProvider: jest.fn().mockImplementation(() => ({
-      all: mockEthcallProviderAll,
+      tryAll: mockEthcallProviderTryAll,
     })),
   };
 });
@@ -151,26 +162,34 @@ describe("Asset drained bot test suite", () => {
       expect(findings).toStrictEqual([]);
     });
 
-    it("should alert if there are contracts with fully drained assets", async () => {
+    it("should alert if there are contracts that had 99% or more of their assets drained", async () => {
       const mockTransferEvent1 = {
         address: asset,
         args: {
           from: address1,
           to: address2,
-          value: ethers.BigNumber.from(10),
+          value: ethers.BigNumber.from(995),
         },
       };
       mockTxEvent.filterLog.mockReturnValueOnce([mockTransferEvent1]);
-      mockEthcallProviderAll.mockResolvedValueOnce([true, [ethers.BigNumber.from(0)]]);
-      mockBalanceOf.mockResolvedValueOnce(ethers.BigNumber.from(10)); // Mock balance 10 mins ago
+      // Balance call for pre-drain balances
+      mockEthcallProviderTryAll.mockResolvedValueOnce([
+        { success: true, returnData: ethers.BigNumber.from(1000) }, // Victim     (address1)
+        { success: true, returnData: ethers.BigNumber.from(50) },   // Exploiter  (address2)
+      ]);
+      // Balance call for post-drain balances
+      mockEthcallProviderTryAll.mockResolvedValueOnce([
+        { success: true, returnData: ethers.BigNumber.from(5) },    // Victim     (address1)
+        { success: true, returnData: ethers.BigNumber.from(1045) }, // Exploiter  (address2)
+      ]);
 
       await handleTransaction(mockTxEvent);
       const findings = await handleBlock(mockBlockEvent);
-      expect(mockEthcallProviderAll).toHaveBeenCalledTimes(1);
+      expect(mockEthcallProviderTryAll).toHaveBeenCalledTimes(2);
       expect(findings).toStrictEqual([
         Finding.fromObject({
           name: "Asset drained",
-          description: `All ${symbol} tokens were drained from ${address1}`,
+          description: `99% or more of ${address1}'s ${symbol} tokens were drained`,
           alertId: "ASSET-DRAINED",
           severity: FindingSeverity.High,
           type: FindingType.Exploit,
@@ -192,7 +211,7 @@ describe("Asset drained bot test suite", () => {
         args: {
           from: address1,
           to: address2,
-          value: ethers.BigNumber.from(8),
+          value: ethers.BigNumber.from(400),
         },
       };
       const mockTransferEvent2 = {
@@ -200,23 +219,33 @@ describe("Asset drained bot test suite", () => {
         args: {
           from: address1,
           to: address3,
-          value: ethers.BigNumber.from(2),
+          value: ethers.BigNumber.from(593),
         },
       };
 
       mockTxEvent.filterLog.mockReturnValueOnce([mockTransferEvent1]);
       mockTxEvent2.filterLog.mockReturnValueOnce([mockTransferEvent2]);
-      mockEthcallProviderAll.mockResolvedValueOnce([true, [ethers.BigNumber.from(0)]]);
-      mockBalanceOf.mockResolvedValueOnce(ethers.BigNumber.from(10)); // Mock balance 10 mins ago
+      // Balance call for pre-drain balances
+      mockEthcallProviderTryAll.mockResolvedValueOnce([
+        { success: true, returnData: ethers.BigNumber.from(1000) }, // Victim       (address1)
+        { success: true, returnData: ethers.BigNumber.from(50) },   // Exploiter 01 (address2)
+        { success: true, returnData: ethers.BigNumber.from(75) },   // Exploiter 02 (address3)
+      ]);
+      // Balance call for post-drain balances
+      mockEthcallProviderTryAll.mockResolvedValueOnce([
+        { success: true, returnData: ethers.BigNumber.from(7) },    // Victim       (address1)
+        { success: true, returnData: ethers.BigNumber.from(450) },  // Exploiter 01 (address2)
+        { success: true, returnData: ethers.BigNumber.from(668) },  // Exploiter 02 (address3)
+      ]);
 
       await handleTransaction(mockTxEvent);
       await handleTransaction(mockTxEvent2);
       const findings = await handleBlock(mockBlockEvent);
-      expect(mockEthcallProviderAll).toHaveBeenCalledTimes(2);
+      expect(mockEthcallProviderAll).mockEthcallProviderTryAll(2);
       expect(findings).toStrictEqual([
         Finding.fromObject({
           name: "Asset drained",
-          description: `All ${symbol} tokens were drained from ${address1}`,
+          description: `99% or more of ${address1}'s ${symbol} tokens were drained`,
           alertId: "ASSET-DRAINED",
           severity: FindingSeverity.High,
           type: FindingType.Exploit,

--- a/asset-drained/src/agent.spec.js
+++ b/asset-drained/src/agent.spec.js
@@ -152,6 +152,7 @@ describe("Asset drained bot test suite", () => {
     beforeEach(() => {
       mockTxEvent.filterLog.mockReset();
       mockTxEvent2.filterLog.mockReset();
+      mockEthcallProviderTryAll.mockReset();
       Object.keys(getTransfersObj()).forEach((key) => delete getTransfersObj()[key]);
     });
 
@@ -241,7 +242,7 @@ describe("Asset drained bot test suite", () => {
       await handleTransaction(mockTxEvent);
       await handleTransaction(mockTxEvent2);
       const findings = await handleBlock(mockBlockEvent);
-      expect(mockEthcallProviderAll).mockEthcallProviderTryAll(2);
+      expect(mockEthcallProviderTryAll).toHaveBeenCalledTimes(2);
       expect(findings).toStrictEqual([
         Finding.fromObject({
           name: "Asset drained",

--- a/asset-drained/src/agent.spec.js
+++ b/asset-drained/src/agent.spec.js
@@ -176,11 +176,11 @@ describe("Asset drained bot test suite", () => {
       // Balance call for pre-drain balances
       mockEthcallProviderTryAll.mockResolvedValueOnce([
         { success: true, returnData: ethers.BigNumber.from(1000) }, // Victim     (address1)
-        { success: true, returnData: ethers.BigNumber.from(50) },   // Exploiter  (address2)
+        { success: true, returnData: ethers.BigNumber.from(50) }, // Exploiter  (address2)
       ]);
       // Balance call for post-drain balances
       mockEthcallProviderTryAll.mockResolvedValueOnce([
-        { success: true, returnData: ethers.BigNumber.from(5) },    // Victim     (address1)
+        { success: true, returnData: ethers.BigNumber.from(5) }, // Victim     (address1)
         { success: true, returnData: ethers.BigNumber.from(1045) }, // Exploiter  (address2)
       ]);
 
@@ -229,14 +229,14 @@ describe("Asset drained bot test suite", () => {
       // Balance call for pre-drain balances
       mockEthcallProviderTryAll.mockResolvedValueOnce([
         { success: true, returnData: ethers.BigNumber.from(1000) }, // Victim       (address1)
-        { success: true, returnData: ethers.BigNumber.from(50) },   // Exploiter 01 (address2)
-        { success: true, returnData: ethers.BigNumber.from(75) },   // Exploiter 02 (address3)
+        { success: true, returnData: ethers.BigNumber.from(50) }, // Exploiter 01 (address2)
+        { success: true, returnData: ethers.BigNumber.from(75) }, // Exploiter 02 (address3)
       ]);
       // Balance call for post-drain balances
       mockEthcallProviderTryAll.mockResolvedValueOnce([
-        { success: true, returnData: ethers.BigNumber.from(7) },    // Victim       (address1)
-        { success: true, returnData: ethers.BigNumber.from(450) },  // Exploiter 01 (address2)
-        { success: true, returnData: ethers.BigNumber.from(668) },  // Exploiter 02 (address3)
+        { success: true, returnData: ethers.BigNumber.from(7) }, // Victim       (address1)
+        { success: true, returnData: ethers.BigNumber.from(450) }, // Exploiter 01 (address2)
+        { success: true, returnData: ethers.BigNumber.from(668) }, // Exploiter 02 (address3)
       ]);
 
       await handleTransaction(mockTxEvent);

--- a/asset-drained/src/agent.spec.js
+++ b/asset-drained/src/agent.spec.js
@@ -175,13 +175,13 @@ describe("Asset drained bot test suite", () => {
       mockTxEvent.filterLog.mockReturnValueOnce([mockTransferEvent1]);
       // Balance call for pre-drain balances
       mockEthcallProviderTryAll.mockResolvedValueOnce([
-        { success: true, returnData: ethers.BigNumber.from(1000) }, // Victim     (address1)
-        { success: true, returnData: ethers.BigNumber.from(50) }, // Exploiter  (address2)
+        { success: true, returnData: ethers.BigNumber.from(1000) }, // Victim (address1)
+        { success: true, returnData: ethers.BigNumber.from(50) }, // Exploiter (address2)
       ]);
       // Balance call for post-drain balances
       mockEthcallProviderTryAll.mockResolvedValueOnce([
-        { success: true, returnData: ethers.BigNumber.from(5) }, // Victim     (address1)
-        { success: true, returnData: ethers.BigNumber.from(1045) }, // Exploiter  (address2)
+        { success: true, returnData: ethers.BigNumber.from(5) }, // Victim (address1)
+        { success: true, returnData: ethers.BigNumber.from(1045) }, // Exploiter (address2)
       ]);
 
       await handleTransaction(mockTxEvent);
@@ -228,13 +228,13 @@ describe("Asset drained bot test suite", () => {
       mockTxEvent2.filterLog.mockReturnValueOnce([mockTransferEvent2]);
       // Balance call for pre-drain balances
       mockEthcallProviderTryAll.mockResolvedValueOnce([
-        { success: true, returnData: ethers.BigNumber.from(1000) }, // Victim       (address1)
+        { success: true, returnData: ethers.BigNumber.from(1000) }, // Victim (address1)
         { success: true, returnData: ethers.BigNumber.from(50) }, // Exploiter 01 (address2)
         { success: true, returnData: ethers.BigNumber.from(75) }, // Exploiter 02 (address3)
       ]);
       // Balance call for post-drain balances
       mockEthcallProviderTryAll.mockResolvedValueOnce([
-        { success: true, returnData: ethers.BigNumber.from(7) }, // Victim       (address1)
+        { success: true, returnData: ethers.BigNumber.from(7) }, // Victim (address1)
         { success: true, returnData: ethers.BigNumber.from(450) }, // Exploiter 01 (address2)
         { success: true, returnData: ethers.BigNumber.from(668) }, // Exploiter 02 (address3)
       ]);

--- a/asset-drained/src/helper.js
+++ b/asset-drained/src/helper.js
@@ -6,30 +6,6 @@ const TOKEN_ABI = [
   "function symbol() external view returns (string memory)",
 ];
 
-// On the rollups every tx is counted as a new block
-// so it isn't possible to get the balance 10 mins ago
-// we hardcode 1000 to get an older balance
-function getBlocksIn10Minutes(network) {
-  switch (network) {
-    case 1:
-      return 50; // 12 seconds per block
-    case 10:
-      return 1000; // rollup
-    case 56:
-      return 120; // 5 seconds per block
-    case 137:
-      return 260; // 2.3 seconds per block
-    case 250:
-      return 500; // 1.2 seconds per block
-    case 42161:
-      return 1000; // rollup
-    case 43114:
-      return 200; // 3 seconds per block
-    default:
-      return 1000;
-  }
-}
-
 function hashCode(address, asset) {
   const str = address + asset;
   let hash = 0;
@@ -68,7 +44,6 @@ async function getAssetSymbol(address, cachedAssetSymbols) {
 }
 
 module.exports = {
-  getBlocksIn10Minutes,
   hashCode,
   getAddressType,
   getAssetSymbol,


### PR DESCRIPTION
* Migrate from `.all()` to `.tryAll()` from `MulticallProvider`
* Update to compare victim's post-drain balance to their pre-drain balance
* Remove checking balance of 10 mins ago (Since we are now checking victim's pre-drain balance **every** time)
* Update tests to check for the update
* Update README to explain new approach