### PR TITLE
fix: fixed false Negative for flashloan detector

### DIFF
--- a/flashloan-detector/src/agent.js
+++ b/flashloan-detector/src/agent.js
@@ -41,6 +41,7 @@ function provideInitialize(
 const transferEventSigs = [
   "event Transfer(address indexed src, address indexed dst, uint wad)",
   "event Withdrawal(address indexed src, uint256 wad)",
+  "event  Deposit(address indexed dst, uint wad)",
 ];
 
 const transferFunctionSigs = [
@@ -66,20 +67,31 @@ function provideHandleTransaction(helper, getFlashloans, provider) {
     let totalNativeProfit = helper.zero;
     let totalBorrowed = 0;
 
+    let flashLoanTokenProfitCalculated = {};
+    let flashLoanNativeProfitCalculated = {};
+
     // For each flashloan calculate the token profits and the borrowed amount
     await Promise.all(
       flashloans.map(async (flashloan, flashloanIndex) => {
         const { asset, amount, account } = flashloan;
 
         if (account !== initiator) {
-          const tokenProfits = helper.calculateTokenProfits(transferEvents, account);
-          const nativeProfit = helper.calculateNativeProfit(traces, account);
+          // Each FlashLoan can have a different account.
+          if (!flashLoanTokenProfitCalculated[account]) {
+            const tokenProfits = helper.calculateTokenProfits(transferEvents, account);
+            const nativeProfit = helper.calculateNativeProfit(traces, account);
 
-          Object.entries(tokenProfits).forEach(([address, profit]) => {
-            if (!totalTokenProfits[address]) totalTokenProfits[address] = helper.zero;
-            totalTokenProfits[address] = totalTokenProfits[address].add(profit);
-          });
-          totalNativeProfit = totalNativeProfit.add(nativeProfit);
+            // console.log(tokenProfits["0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"].toString());
+
+            flashLoanTokenProfitCalculated[account] = true;
+            flashLoanNativeProfitCalculated[account] = true;
+
+            Object.entries(tokenProfits).forEach(([address, profit]) => {
+              if (!totalTokenProfits[address]) totalTokenProfits[address] = helper.zero;
+              totalTokenProfits[address] = totalTokenProfits[address].add(profit);
+            });
+            totalNativeProfit = totalNativeProfit.add(nativeProfit);
+          }
         }
 
         // Only loop through traces if on mainnet Ethereum
@@ -94,8 +106,12 @@ function provideHandleTransaction(helper, getFlashloans, provider) {
                 (from.toLowerCase() === account || from.toLowerCase() === calledContract) &&
                 to.toLowerCase() === initiator
               ) {
-                const nativeProfit = helper.calculateNativeProfit(traces, initiator);
-                totalNativeProfit = totalNativeProfit.add(nativeProfit);
+                // making sure that Native Profits are calcualted only once for the initiator.
+                if (!flashLoanNativeProfitCalculated[initiator]) {
+                  const nativeProfit = helper.calculateNativeProfit(traces, initiator);
+                  totalNativeProfit = totalNativeProfit.add(nativeProfit);
+                  flashLoanNativeProfitCalculated[initiator] = true;
+                }
                 break traceLoop;
               } else if (
                 (from.toLowerCase() === account || from.toLowerCase() === calledContract) &&
@@ -131,16 +147,20 @@ function provideHandleTransaction(helper, getFlashloans, provider) {
                   (src.toLowerCase() === calledContract || src.toLowerCase() === account) &&
                   dst.toLowerCase() === initiator
                 ) {
-                  const tokenProfits = helper.calculateTokenProfits(transferEvents, initiator);
-                  const positiveProfits = Object.values(tokenProfits).filter((profit) => profit > helper.zero);
-                  if (positiveProfits.length === 0) {
-                    continue;
+                  // making sure that token Profits are calcualted only once for the initiator.
+                  if (!flashLoanTokenProfitCalculated[initiator]) {
+                    const tokenProfits = helper.calculateTokenProfits(transferEvents, initiator);
+                    const positiveProfits = Object.values(tokenProfits).filter((profit) => profit > helper.zero);
+                    if (positiveProfits.length === 0) {
+                      continue;
+                    }
+
+                    Object.entries(tokenProfits).forEach(([address, profit]) => {
+                      if (!totalTokenProfits[address]) totalTokenProfits[address] = helper.zero;
+                      totalTokenProfits[address] = totalTokenProfits[address].add(profit);
+                    });
                   }
 
-                  Object.entries(tokenProfits).forEach(([address, profit]) => {
-                    if (!totalTokenProfits[address]) totalTokenProfits[address] = helper.zero;
-                    totalTokenProfits[address] = totalTokenProfits[address].add(profit);
-                  });
                   break traceLoop;
                 } else if (
                   name === "Transfer" &&


### PR DESCRIPTION
- Added `flashLoanTokenProfitCalculated` and `flashLoanNativeProfitCalculated` to ensure that for a flash Loan account, the profits will be calculated only once.
- The bot was initially tracking the Withdrawal events but it was not tracking the Deposit events which ultimately resulted in negative profit. So added `Deposit` event for the `transferEventSigs`
- Tested Bot by running npm test. All tests are passing
- Also manually tested the bot by running the given two test transactions and the conicFinace transaction. All transactions are returning findings. 