### PR TITLE
FORT02.07 - Flashloan Detector (AD FP Fix)

### DIFF
--- a/flashloan-detector/package-lock.json
+++ b/flashloan-detector/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashloan-detection-bot",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashloan-detection-bot",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "axios": "^0.27.2",
         "dotenv": "^16.0.3",

--- a/flashloan-detector/package.json
+++ b/flashloan-detector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flashloan-detection-bot",
   "displayName": "Flashloan Detection Bot",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Forta bot that detects if a transaction contains a flashloan where the borrower makes large profit",
   "longDescription": "This bot focuses on detecting instances of flashloan utilization, the bot diligently examines each transaction to determine if it aligns with the characteristics of a flashloan. It further analyzes the transaction to assess whether the borrower has generated a substantial profit, using a preset percentage threshold. The bot's function is activated solely in cases where both a flashloan is involved and the borrower's profit meets the specified criteria, providing an objective mechanism for identifying these specific transaction types.",
   "repository": "https://github.com/NethermindEth/forta-starter-kits/tree/main/flashloan-detector",

--- a/flashloan-detector/src/agent.js
+++ b/flashloan-detector/src/agent.js
@@ -17,6 +17,7 @@ let hasCalledContractBeenProcessed = {
 const PROFIT_THRESHOLD = 200_000;
 const PERCENTAGE_THRESHOLD = 1.3;
 const PROFIT_THRESHOLD_WITH_HIGH_PERCENTAGE = 100_000;
+const STANDARD_ALERT_PROFIT_THRESHOLD = 1000;
 const cache = new LRUCache({ max: 100_000 });
 const processedAccounts = new Set();
 
@@ -342,7 +343,7 @@ function provideHandleTransaction(helper, getFlashloans, provider) {
           ],
         })
       );
-    } else if (percentage > PERCENTAGE_THRESHOLD) {
+    } else if (percentage > PERCENTAGE_THRESHOLD && totalProfit >= STANDARD_ALERT_PROFIT_THRESHOLD) {
       detectedFlashloans += 1;
       const anomalyScore = detectedFlashloans / totalFlashloans;
       findings.push(


### PR DESCRIPTION
Related Issue: https://github.com/forta-network/starter-kits/issues/612
Notes:
1) Attack Detector is subscribed to both Flashloan detector alerts (`FLASHLOAN-ATTACK`and `FLASHLOAN-ATTACK-HIGH-PROFIT`) without making any distinction between them
2) The profits in the flashloan alerts of the issue were very low ($20 and $32)

Instead of trying to exclude arbitrage transactions (which would be quite an elaborate change), I suggest integrating a profit threshold check even for the "standard" `FLASHLOAN-ATTACK` alert (set at $1000) to reduce the number of standard alerts  (thereby also reducing AD FPs).

If the issue persists, we might then consider unsubscribing from the standard alert (and perhaps lower the threshold of the "high profit" flashloan alert at the same time)